### PR TITLE
Add alias support to uninstall and list

### DIFF
--- a/tests/cli/test_ethpm.py
+++ b/tests/cli/test_ethpm.py
@@ -24,6 +24,17 @@ def test_ethpm_list(test_assets_dir):
     )
 
 
+def test_ethpm_list_with_aliased_package(test_assets_dir):
+    ethpm_dir = test_assets_dir / "owned" / "ipfs_uri_alias" / "_ethpm_packages"
+    child = pexpect.spawn(f"ethpm list --ethpm-dir {ethpm_dir}")
+    child.expect("EthPM CLI v0.1.0a0\r\n")
+    child.expect("\r\n")
+    child.expect(
+        "owned @ owned-alias==1.0.0 --- "
+        r"\(ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW\)\r\n"
+    )
+
+
 def test_ethpm_install(tmp_path, test_assets_dir):
     ethpm_dir = tmp_path / "_ethpm_packages"
     ethpm_dir.mkdir()
@@ -62,4 +73,30 @@ def test_unsupported_command():
     child.expect(
         "ethpm: error: argument command: invalid choice: 'invalid' "
         r"\(choose from 'scrape', 'install', 'uninstall', 'list'\)\r\n"
+    )
+
+
+def test_ethpm_uninstall_nonexistent_package(tmp_path):
+    ethpm_dir = tmp_path / "_ethpm_packages"
+    ethpm_dir.mkdir()
+    child = pexpect.spawn(f"ethpm uninstall owned --ethpm-dir {ethpm_dir}")
+    child.expect(
+        f"No package with the name owned found installed under {ethpm_dir}.\r\n"
+    )
+
+
+def test_ethpm_uninstall_aliased_package(tmp_path, test_assets_dir):
+    ethpm_dir = tmp_path / "_ethpm_packages"
+    shutil.copytree(
+        test_assets_dir / "owned" / "ipfs_uri_alias" / "_ethpm_packages", ethpm_dir
+    )
+    assert check_dir_trees_equal(
+        ethpm_dir, test_assets_dir / "owned" / "ipfs_uri_alias" / "_ethpm_packages"
+    )
+    child = pexpect.spawn(f"ethpm uninstall owned --ethpm-dir {ethpm_dir}")
+    child.expect("EthPM CLI v0.1.0a0\r\n")
+    child.expect("\r\n")
+    child.expect(r"Found owned installed under the alias\(es\): \('owned-alias',\). ")
+    child.expect(
+        "To uninstall an aliased package, use the alias as the uninstall argument.\r\n"
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import tempfile
 
 import pytest
 
@@ -8,3 +9,10 @@ ASSETS_DIR = Path(__file__).parent / "core" / "assets"
 @pytest.fixture
 def test_assets_dir():
     return ASSETS_DIR
+
+
+@pytest.fixture(autouse=True)
+def _clean_current_working_directory(monkeypatch):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        monkeypatch.chdir(temp_dir)
+        yield


### PR DESCRIPTION
## What was wrong?
Fixes #20 
`ethpm list` now displays package aliases, if package is aliased, alongside package names
`package_name @ alias == version --- (uri)`


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/58255845-2c065d80-7d6e-11e9-901e-6a1cfd006222.png)
