### PR TITLE
Write documentation to disk if present in manifest

### DIFF
--- a/ethpm_cli/install.py
+++ b/ethpm_cli/install.py
@@ -152,6 +152,7 @@ def write_pkg_installation_files(
     (tmp_pkg_dir / "manifest.json").write_bytes(pkg.raw_manifest)
 
     write_sources_to_disk(pkg, tmp_pkg_dir, ipfs_backend)
+    write_docs_to_disk(pkg, tmp_pkg_dir, ipfs_backend)
     write_build_deps_to_disk(pkg, tmp_pkg_dir, ipfs_backend)
     tmp_ethpm_lock = tmp_pkg_dir.parent / LOCKFILE_NAME
     install_to_ethpm_lock(pkg, tmp_ethpm_lock)
@@ -182,6 +183,21 @@ def resolve_sources(
             # for inlined sources
             contents = source
         yield path, contents
+
+
+def write_docs_to_disk(
+    pkg: Package, pkg_dir: Path, ipfs_backend: BaseIPFSBackend
+) -> None:
+    try:
+        doc_uri = pkg.manifest["meta"]["links"]["documentation"]
+    except KeyError:
+        return
+
+    if is_ipfs_uri(doc_uri):
+        documentation = ipfs_backend.fetch_uri_contents(doc_uri)
+        doc_path = pkg_dir / "documentation.md"
+        doc_path.touch()
+        doc_path.write_bytes(documentation)
 
 
 def write_build_deps_to_disk(

--- a/tests/core/assets/multiple/_ethpm_packages/owned/documentation.md
+++ b/tests/core/assets/multiple/_ethpm_packages/owned/documentation.md
@@ -1,0 +1,35 @@
+# @contract 
+owned.sol
+
+# @dev 
+The owned contract stores an 'owner' address, and provides a modifier for 
+basic authorization control functions.
+
+# @metadata
+```json
+{
+  "language":"Solidity",
+  "output":{  
+    "abi":[  
+      {  
+        "inputs":[  
+
+        ],
+        "payable":false,
+        "stateMutability":"nonpayable",
+        "type":"constructor"
+      }
+    ],
+    "devdoc":{  
+      "methods":{  
+
+      }
+    },
+    "userdoc":{  
+      "methods":{  
+
+      }
+    }
+  }
+}
+```

--- a/tests/core/assets/multiple/_ethpm_packages/wallet/_ethpm_packages/owned/documentation.md
+++ b/tests/core/assets/multiple/_ethpm_packages/wallet/_ethpm_packages/owned/documentation.md
@@ -1,0 +1,35 @@
+# @contract 
+owned.sol
+
+# @dev 
+The owned contract stores an 'owner' address, and provides a modifier for 
+basic authorization control functions.
+
+# @metadata
+```json
+{
+  "language":"Solidity",
+  "output":{  
+    "abi":[  
+      {  
+        "inputs":[  
+
+        ],
+        "payable":false,
+        "stateMutability":"nonpayable",
+        "type":"constructor"
+      }
+    ],
+    "devdoc":{  
+      "methods":{  
+
+      }
+    },
+    "userdoc":{  
+      "methods":{  
+
+      }
+    }
+  }
+}
+```

--- a/tests/core/assets/owned/ipfs_uri/_ethpm_packages/owned/documentation.md
+++ b/tests/core/assets/owned/ipfs_uri/_ethpm_packages/owned/documentation.md
@@ -1,0 +1,35 @@
+# @contract 
+owned.sol
+
+# @dev 
+The owned contract stores an 'owner' address, and provides a modifier for 
+basic authorization control functions.
+
+# @metadata
+```json
+{
+  "language":"Solidity",
+  "output":{  
+    "abi":[  
+      {  
+        "inputs":[  
+
+        ],
+        "payable":false,
+        "stateMutability":"nonpayable",
+        "type":"constructor"
+      }
+    ],
+    "devdoc":{  
+      "methods":{  
+
+      }
+    },
+    "userdoc":{  
+      "methods":{  
+
+      }
+    }
+  }
+}
+```

--- a/tests/core/assets/owned/ipfs_uri_alias/_ethpm_packages/owned-alias/documentation.md
+++ b/tests/core/assets/owned/ipfs_uri_alias/_ethpm_packages/owned-alias/documentation.md
@@ -1,0 +1,35 @@
+# @contract 
+owned.sol
+
+# @dev 
+The owned contract stores an 'owner' address, and provides a modifier for 
+basic authorization control functions.
+
+# @metadata
+```json
+{
+  "language":"Solidity",
+  "output":{  
+    "abi":[  
+      {  
+        "inputs":[  
+
+        ],
+        "payable":false,
+        "stateMutability":"nonpayable",
+        "type":"constructor"
+      }
+    ],
+    "devdoc":{  
+      "methods":{  
+
+      }
+    },
+    "userdoc":{  
+      "methods":{  
+
+      }
+    }
+  }
+}
+```

--- a/tests/core/assets/owned/registry_uri/_ethpm_packages/owned/documentation.md
+++ b/tests/core/assets/owned/registry_uri/_ethpm_packages/owned/documentation.md
@@ -1,0 +1,35 @@
+# @contract 
+owned.sol
+
+# @dev 
+The owned contract stores an 'owner' address, and provides a modifier for 
+basic authorization control functions.
+
+# @metadata
+```json
+{
+  "language":"Solidity",
+  "output":{  
+    "abi":[  
+      {  
+        "inputs":[  
+
+        ],
+        "payable":false,
+        "stateMutability":"nonpayable",
+        "type":"constructor"
+      }
+    ],
+    "devdoc":{  
+      "methods":{  
+
+      }
+    },
+    "userdoc":{  
+      "methods":{  
+
+      }
+    }
+  }
+}
+```

--- a/tests/core/assets/wallet/ipfs_uri/_ethpm_packages/wallet/_ethpm_packages/owned/documentation.md
+++ b/tests/core/assets/wallet/ipfs_uri/_ethpm_packages/wallet/_ethpm_packages/owned/documentation.md
@@ -1,0 +1,35 @@
+# @contract 
+owned.sol
+
+# @dev 
+The owned contract stores an 'owner' address, and provides a modifier for 
+basic authorization control functions.
+
+# @metadata
+```json
+{
+  "language":"Solidity",
+  "output":{  
+    "abi":[  
+      {  
+        "inputs":[  
+
+        ],
+        "payable":false,
+        "stateMutability":"nonpayable",
+        "type":"constructor"
+      }
+    ],
+    "devdoc":{  
+      "methods":{  
+
+      }
+    },
+    "userdoc":{  
+      "methods":{  
+
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
## What was wrong?
Now `ethpm install` will write documentation to disk under `documentation.md` if an ipfs uri is present in manifest metadata

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/59555408-dee16a00-8f6e-11e9-8fd0-608279334250.png)
