### PR TITLE
Write initial authorization utils

### DIFF
--- a/ethpm_cli/auth.py
+++ b/ethpm_cli/auth.py
@@ -2,10 +2,18 @@ import os
 from typing import Optional
 
 from eth_account import Account
+import eth_keyfile
 from eth_typing import Address
+from eth_utils import to_bytes
 
-from ethpm_cli.constants import PRIVATE_KEY_ENV_VAR
+from ethpm_cli.constants import KEYFILE_PASSWORD, KEYFILE_PATH
 from ethpm_cli.exceptions import ValidationError
+
+
+def set_auth(keyfile_path: str, password: str) -> None:
+    validate_keyfile_path_and_password(keyfile_path, to_bytes(text=password))
+    os.environ[KEYFILE_PATH] = keyfile_path
+    os.environ[KEYFILE_PASSWORD] = password
 
 
 def get_authorized_address() -> Address:
@@ -14,16 +22,19 @@ def get_authorized_address() -> Address:
 
 
 def get_authorized_private_key() -> Optional[str]:
-    private_key = os.getenv(PRIVATE_KEY_ENV_VAR)
-    if private_key:
-        validate_private_key(private_key)
-        return private_key
-    return None
-
-
-def validate_private_key(key: str) -> None:
-    if len(key) != 64:
+    keyfile_path = os.getenv(KEYFILE_PATH)
+    password = to_bytes(text=os.getenv(KEYFILE_PASSWORD))
+    if not keyfile_path or not password:
         raise ValidationError(
-            f"Private key ({key}) stored under environment variable: "
-            f"{PRIVATE_KEY_ENV_VAR} is not a valid private key."
+            "Must set password-protected keyfile via `ethpm auth` command."
         )
+    validate_keyfile_path_and_password(keyfile_path, password)
+    private_key = eth_keyfile.extract_key_from_keyfile(keyfile_path, password)
+    return private_key
+
+
+def validate_keyfile_path_and_password(keyfile_path: str, password: str) -> None:
+    try:
+        eth_keyfile.extract_key_from_keyfile(keyfile_path, password)
+    except ValueError:
+        raise ValidationError(f"Invalid keyfile password.")

--- a/ethpm_cli/auth.py
+++ b/ethpm_cli/auth.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import tempfile
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import eth_keyfile
 from eth_typing import Address
@@ -49,7 +49,7 @@ def get_authorized_address() -> Address:
     return keyfile["address"]
 
 
-def get_authorized_private_key(password: str) -> Optional[str]:
+def get_authorized_private_key(password: str) -> str:
     """
     Returns the private key associated with stored keyfile. Password required.
     """

--- a/ethpm_cli/auth.py
+++ b/ethpm_cli/auth.py
@@ -1,0 +1,29 @@
+import os
+from typing import Optional
+
+from eth_account import Account
+from eth_typing import Address
+
+from ethpm_cli.constants import PRIVATE_KEY_ENV_VAR
+from ethpm_cli.exceptions import ValidationError
+
+
+def get_authorized_address() -> Address:
+    private_key = get_authorized_private_key()
+    return Account.from_key(private_key).address
+
+
+def get_authorized_private_key() -> Optional[str]:
+    private_key = os.getenv(PRIVATE_KEY_ENV_VAR)
+    if private_key:
+        validate_private_key(private_key)
+        return private_key
+    return None
+
+
+def validate_private_key(key: str) -> None:
+    if len(key) != 64:
+        raise ValidationError(
+            f"Private key ({key}) stored under environment variable: "
+            f"{PRIVATE_KEY_ENV_VAR} is not a valid private key."
+        )

--- a/ethpm_cli/auth.py
+++ b/ethpm_cli/auth.py
@@ -1,4 +1,6 @@
 import os
+from pathlib import Path
+import tempfile
 from typing import Optional
 
 from eth_account import Account
@@ -8,33 +10,53 @@ from eth_utils import to_bytes
 
 from ethpm_cli.constants import KEYFILE_PASSWORD, KEYFILE_PATH
 from ethpm_cli.exceptions import ValidationError
+from ethpm_cli._utils.xdg import get_xdg_ethpmcli_root
 
 
-def set_auth(keyfile_path: str, password: str) -> None:
-    validate_keyfile_path_and_password(keyfile_path, to_bytes(text=password))
-    os.environ[KEYFILE_PATH] = keyfile_path
-    os.environ[KEYFILE_PASSWORD] = password
+def import_keyfile(keyfile_path: Path):
+    validate_keyfile(keyfile_path)
+    ethpm_xdg_root = get_xdg_ethpmcli_root()
+    ethpm_cli_keyfile_path = ethpm_xdg_root / KEYFILE_PATH
+    tmp_keyfile = Path(tempfile.NamedTemporaryFile().name)
+    tmp_keyfile.write_text(keyfile_path.read_text())
+    tmp_keyfile.replace(ethpm_cli_keyfile_path)
+
+
+def get_keyfile_path():
+    ethpm_xdg_root = get_xdg_ethpmcli_root()
+    keyfile_path = ethpm_xdg_root / KEYFILE_PATH
+    if not keyfile_path.exists():
+        raise Exception
+    return keyfile_path
+
+
+def get_keyfile_data():
+    keyfile_path = get_keyfile_path()
+    return eth_keyfile.load_keyfile(str(keyfile_path))
+
+
+def validate_keyfile(keyfile_path: Path):
+    keyfile_data = eth_keyfile.load_keyfile(str(keyfile_path))
+    if keyfile_data["version"] != 3:
+        raise ValidationError(
+            f"Keyfile found at {keyfile_path} does not look like a supported eth-keyfile object."
+        )
 
 
 def get_authorized_address() -> Address:
-    private_key = get_authorized_private_key()
-    return Account.from_key(private_key).address
+    """
+    Returns the address associated with stored keyfile.
+    """
+    keyfile = get_keyfile_data()
+    return keyfile["address"]
 
 
-def get_authorized_private_key() -> Optional[str]:
-    keyfile_path = os.getenv(KEYFILE_PATH)
-    password = to_bytes(text=os.getenv(KEYFILE_PASSWORD))
-    if not keyfile_path or not password:
-        raise ValidationError(
-            "Must set password-protected keyfile via `ethpm auth` command."
-        )
-    validate_keyfile_path_and_password(keyfile_path, password)
-    private_key = eth_keyfile.extract_key_from_keyfile(keyfile_path, password)
+def get_authorized_private_key(password: str) -> Optional[str]:
+    keyfile_path = get_keyfile_path()
+    password_bytes = to_bytes(text=password)
+    if not password:
+        raise ValidationError("need password")
+    private_key = eth_keyfile.extract_key_from_keyfile(
+        str(keyfile_path), password_bytes
+    )
     return private_key
-
-
-def validate_keyfile_path_and_password(keyfile_path: str, password: str) -> None:
-    try:
-        eth_keyfile.extract_key_from_keyfile(keyfile_path, password)
-    except ValueError:
-        raise ValidationError(f"Invalid keyfile password.")

--- a/ethpm_cli/auth.py
+++ b/ethpm_cli/auth.py
@@ -1,19 +1,17 @@
-import os
 from pathlib import Path
 import tempfile
-from typing import Optional
+from typing import Any, Dict, Optional
 
-from eth_account import Account
 import eth_keyfile
 from eth_typing import Address
 from eth_utils import to_bytes
 
-from ethpm_cli.constants import KEYFILE_PASSWORD, KEYFILE_PATH
-from ethpm_cli.exceptions import ValidationError
 from ethpm_cli._utils.xdg import get_xdg_ethpmcli_root
+from ethpm_cli.constants import KEYFILE_PATH
+from ethpm_cli.exceptions import AuthorizationError
 
 
-def import_keyfile(keyfile_path: Path):
+def import_keyfile(keyfile_path: Path) -> None:
     validate_keyfile(keyfile_path)
     ethpm_xdg_root = get_xdg_ethpmcli_root()
     ethpm_cli_keyfile_path = ethpm_xdg_root / KEYFILE_PATH
@@ -22,41 +20,41 @@ def import_keyfile(keyfile_path: Path):
     tmp_keyfile.replace(ethpm_cli_keyfile_path)
 
 
-def get_keyfile_path():
+def get_keyfile_path() -> Path:
     ethpm_xdg_root = get_xdg_ethpmcli_root()
     keyfile_path = ethpm_xdg_root / KEYFILE_PATH
-    if not keyfile_path.exists():
-        raise Exception
+    if not keyfile_path.is_file():
+        raise AuthorizationError(f"No keyfile located at {keyfile_path}.")
     return keyfile_path
 
 
-def get_keyfile_data():
+def get_keyfile_data() -> Dict[str, Any]:
     keyfile_path = get_keyfile_path()
     return eth_keyfile.load_keyfile(str(keyfile_path))
 
 
-def validate_keyfile(keyfile_path: Path):
+def validate_keyfile(keyfile_path: Path) -> None:
     keyfile_data = eth_keyfile.load_keyfile(str(keyfile_path))
     if keyfile_data["version"] != 3:
-        raise ValidationError(
+        raise AuthorizationError(
             f"Keyfile found at {keyfile_path} does not look like a supported eth-keyfile object."
         )
 
 
 def get_authorized_address() -> Address:
     """
-    Returns the address associated with stored keyfile.
+    Returns the address associated with stored keyfile. No password required.
     """
     keyfile = get_keyfile_data()
     return keyfile["address"]
 
 
 def get_authorized_private_key(password: str) -> Optional[str]:
+    """
+    Returns the private key associated with stored keyfile. Password required.
+    """
     keyfile_path = get_keyfile_path()
-    password_bytes = to_bytes(text=password)
-    if not password:
-        raise ValidationError("need password")
     private_key = eth_keyfile.extract_key_from_keyfile(
-        str(keyfile_path), password_bytes
+        str(keyfile_path), to_bytes(text=password)
     )
     return private_key

--- a/ethpm_cli/constants.py
+++ b/ethpm_cli/constants.py
@@ -12,5 +12,4 @@ VERSION_RELEASE_ABI = json.loads((CLI_ASSETS_DIR / "1.0.1.json").read_text())[
     "contract_types"
 ]["Log"]["abi"]
 INFURA_HTTP_URI = f"https://mainnet.infura.io/v3/4f1a358967c7474aae6f8f4a7698aefc"
-KEYFILE_PASSWORD = "ETHPM_CLI_KEYFILE_PASSWORD"
-KEYFILE_PATH = "ETHPM_CLI_KEYFILE_PATH"
+KEYFILE_PATH = "_ethpm_keyfile.json"

--- a/ethpm_cli/constants.py
+++ b/ethpm_cli/constants.py
@@ -12,3 +12,4 @@ VERSION_RELEASE_ABI = json.loads((CLI_ASSETS_DIR / "1.0.1.json").read_text())[
     "contract_types"
 ]["Log"]["abi"]
 INFURA_HTTP_URI = f"https://mainnet.infura.io/v3/4f1a358967c7474aae6f8f4a7698aefc"
+PRIVATE_KEY_ENV_VAR = "ETHPM_CLI_PRIVATE_KEY"

--- a/ethpm_cli/constants.py
+++ b/ethpm_cli/constants.py
@@ -12,4 +12,5 @@ VERSION_RELEASE_ABI = json.loads((CLI_ASSETS_DIR / "1.0.1.json").read_text())[
     "contract_types"
 ]["Log"]["abi"]
 INFURA_HTTP_URI = f"https://mainnet.infura.io/v3/4f1a358967c7474aae6f8f4a7698aefc"
-PRIVATE_KEY_ENV_VAR = "ETHPM_CLI_PRIVATE_KEY"
+KEYFILE_PASSWORD = "ETHPM_CLI_KEYFILE_PASSWORD"
+KEYFILE_PATH = "ETHPM_CLI_KEYFILE_PATH"

--- a/ethpm_cli/exceptions.py
+++ b/ethpm_cli/exceptions.py
@@ -44,3 +44,11 @@ class AmbigiousFileSystem(BaseEthpmCliError):
     """
 
     pass
+
+
+class AuthorizationError(BaseEthpmCliError):
+    """
+    Raised when there is insufficient authorization to perform a task.
+    """
+
+    pass

--- a/ethpm_cli/parser.py
+++ b/ethpm_cli/parser.py
@@ -8,6 +8,7 @@ from web3.providers.auto import load_provider_from_uri
 
 from ethpm_cli._utils.logger import cli_logger
 from ethpm_cli._utils.xdg import get_xdg_ethpmcli_root
+from ethpm_cli.auth import get_authorized_address, set_auth
 from ethpm_cli.config import Config
 from ethpm_cli.constants import INFURA_HTTP_URI
 from ethpm_cli.install import (
@@ -21,6 +22,27 @@ from ethpm_cli.validation import validate_install_cli_args, validate_uninstall_c
 
 parser = argparse.ArgumentParser(description="ethpm-cli")
 ethpm_parser = parser.add_subparsers(help="commands", dest="command")
+
+
+#
+# ethpm auth
+#
+
+
+def auth_action(args: argparse.Namespace) -> None:
+    set_auth(args.keystore_path, args.password)
+    authorized_address = get_authorized_address()
+    cli_logger.info(f"Authorization enabled for address: {authorized_address}.")
+
+
+auth_parser = ethpm_parser.add_parser("auth", help="auth")
+auth_parser.add_argument(
+    "keystore_path", action="store", type=str, help="Path to your keyfile"
+)
+auth_parser.add_argument(
+    "password", action="store", type=str, help="Password for keyfile."
+)
+auth_parser.set_defaults(func=auth_action)
 
 
 #

--- a/ethpm_cli/parser.py
+++ b/ethpm_cli/parser.py
@@ -8,7 +8,7 @@ from web3.providers.auto import load_provider_from_uri
 
 from ethpm_cli._utils.logger import cli_logger
 from ethpm_cli._utils.xdg import get_xdg_ethpmcli_root
-from ethpm_cli.auth import get_authorized_address, set_auth
+from ethpm_cli.auth import get_authorized_address, import_keyfile
 from ethpm_cli.config import Config
 from ethpm_cli.constants import INFURA_HTTP_URI
 from ethpm_cli.install import (
@@ -30,18 +30,19 @@ ethpm_parser = parser.add_subparsers(help="commands", dest="command")
 
 
 def auth_action(args: argparse.Namespace) -> None:
-    set_auth(args.keystore_path, args.password)
+    config = Config(args)
+    import_keyfile(args.keystore_path, config)
     authorized_address = get_authorized_address()
-    cli_logger.info(f"Authorization enabled for address: {authorized_address}.")
+    cli_logger.info(f"Keyfile copied to ethPM CLI for address: {authorized_address}.")
 
 
 auth_parser = ethpm_parser.add_parser("auth", help="auth")
 auth_parser.add_argument(
     "keystore_path", action="store", type=str, help="Path to your keyfile"
 )
-auth_parser.add_argument(
-    "password", action="store", type=str, help="Password for keyfile."
-)
+# auth_parser.add_argument(
+# "password", action="store", type=str, help="Password for keyfile."
+# )
 auth_parser.set_defaults(func=auth_action)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,11 @@
+from argparse import Namespace
 from pathlib import Path
 import tempfile
 
 import pytest
+
+from ethpm_cli.config import Config
+from ethpm_cli.constants import ETHPM_DIR_NAME
 
 ASSETS_DIR = Path(__file__).parent / "core" / "assets"
 
@@ -9,6 +13,18 @@ ASSETS_DIR = Path(__file__).parent / "core" / "assets"
 @pytest.fixture
 def test_assets_dir():
     return ASSETS_DIR
+
+
+@pytest.fixture
+def config(tmpdir):
+    namespace = Namespace()
+    ethpm_dir = Path(tmpdir) / ETHPM_DIR_NAME
+    ethpm_dir.mkdir()
+    namespace.local_ipfs = False
+    namespace.install_uri = None
+    namespace.alias = None
+    namespace.ethpm_dir = ethpm_dir
+    return Config(namespace)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,13 @@
 from argparse import Namespace
+import json
 from pathlib import Path
 import tempfile
 
+import eth_keyfile
 import pytest
 
 from ethpm_cli.config import Config
-from ethpm_cli.constants import ETHPM_DIR_NAME
+from ethpm_cli.constants import ETHPM_DIR_NAME, KEYFILE_PATH
 
 ASSETS_DIR = Path(__file__).parent / "core" / "assets"
 
@@ -25,6 +27,28 @@ def config(tmpdir):
     namespace.alias = None
     namespace.ethpm_dir = ethpm_dir
     return Config(namespace)
+
+
+@pytest.fixture
+def keyfile_auth():
+    private_key = b"\x01" * 32
+    address = "0x1a642f0E3c3aF545E7AcBD38b07251B3990914F1"
+    password = b"password"
+    return private_key, address, password
+
+
+@pytest.fixture
+def keyfile(monkeypatch, tmpdir, keyfile_auth):
+    private_key, _, password = keyfile_auth
+    monkeypatch.chdir(tmpdir)
+    ethpmcli_dir = Path(tmpdir / "ethpmcli_dir")
+    ethpmcli_dir.mkdir()
+    monkeypatch.setenv("XDG_ETHPMCLI_ROOT", str(ethpmcli_dir))
+    tmp_keyfile = ethpmcli_dir / KEYFILE_PATH
+    tmp_keyfile.touch()
+    keyfile_json = eth_keyfile.create_keyfile_json(private_key, password)
+    tmp_keyfile.write_text(json.dumps(keyfile_json))
+    return tmp_keyfile
 
 
 @pytest.fixture(autouse=True)

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,23 +1,8 @@
-from argparse import Namespace
 import json
-from pathlib import Path
 
 import pytest
 
-from ethpm_cli.config import Config
 from ethpm_cli.constants import ETHPM_DIR_NAME
-
-
-@pytest.fixture
-def config(tmpdir):
-    namespace = Namespace()
-    ethpm_dir = Path(tmpdir) / ETHPM_DIR_NAME
-    ethpm_dir.mkdir()
-    namespace.local_ipfs = False
-    namespace.install_uri = None
-    namespace.alias = None
-    namespace.ethpm_dir = ethpm_dir
-    return Config(namespace)
 
 
 @pytest.fixture

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,8 +1,23 @@
+from argparse import Namespace
 import json
+from pathlib import Path
 
 import pytest
 
+from ethpm_cli.config import Config
 from ethpm_cli.constants import ETHPM_DIR_NAME
+
+
+@pytest.fixture
+def config(tmpdir):
+    namespace = Namespace()
+    ethpm_dir = Path(tmpdir) / ETHPM_DIR_NAME
+    ethpm_dir.mkdir()
+    namespace.local_ipfs = False
+    namespace.install_uri = None
+    namespace.alias = None
+    namespace.ethpm_dir = ethpm_dir
+    return Config(namespace)
 
 
 @pytest.fixture

--- a/tests/core/test_auth.py
+++ b/tests/core/test_auth.py
@@ -1,8 +1,7 @@
-from pathlib import Path
-import tempfile
 import filecmp
 import json
 import os
+from pathlib import Path
 
 import eth_keyfile
 from eth_utils import is_same_address, to_text
@@ -13,8 +12,7 @@ from ethpm_cli.auth import (
     get_authorized_private_key,
     import_keyfile,
 )
-from ethpm_cli.constants import KEYFILE_PASSWORD, KEYFILE_PATH
-from ethpm_cli.exceptions import ValidationError
+from ethpm_cli.constants import KEYFILE_PATH
 
 PRIVATE_KEY = b"\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"  # noqa: E501
 ADDRESS = "0x1a642f0E3c3aF545E7AcBD38b07251B3990914F1"
@@ -35,7 +33,6 @@ def keyfile(monkeypatch, tmpdir):
 
 
 def test_import_keyfile(keyfile):
-    # is this even testing anything useful?
     ethpmcli_dir = Path(os.environ["XDG_ETHPMCLI_ROOT"])
     import_keyfile(keyfile)
     assert filecmp.cmp(ethpmcli_dir / KEYFILE_PATH, keyfile)

--- a/tests/core/test_auth.py
+++ b/tests/core/test_auth.py
@@ -1,0 +1,39 @@
+import pytest
+
+from ethpm_cli.auth import get_authorized_address, get_authorized_private_key
+from ethpm_cli.constants import PRIVATE_KEY_ENV_VAR
+
+PRIVATE_KEY = "b1febf5283d3514c7bc5be3ce6b034d227c8159e85bb6e958181cd09525ce5b9"
+ADDRESS = "0xabc4FC248969137A5078DE7b685C4E7f7AC3Be26"
+
+
+def test_get_auth_private_key(monkeypatch):
+    monkeypatch.setenv(PRIVATE_KEY_ENV_VAR, PRIVATE_KEY)
+    actual_priv_key = get_authorized_private_key()
+    assert actual_priv_key == PRIVATE_KEY
+
+
+@pytest.mark.parametrize(
+    "key",
+    (
+        1,
+        {},
+        None,
+        True,
+        "xxx",
+        # 63 chars
+        "000000000000000000000000000000000000000000000000000000000000000",
+        # 65 chars
+        "00000000000000000000000000000000000000000000000000000000000000000",
+    ),
+)
+def test_get_auth_private_key_raises_exception_with_invalid_key(key, monkeypatch):
+    monkeypatch.setenv(PRIVATE_KEY_ENV_VAR, key)
+    with pytest.raises(Exception, match="is not a valid private key."):
+        get_authorized_private_key()
+
+
+def test_get_authorized_address(monkeypatch):
+    monkeypatch.setenv(PRIVATE_KEY_ENV_VAR, PRIVATE_KEY)
+    auth_address = get_authorized_address()
+    assert auth_address == ADDRESS

--- a/tests/core/test_auth.py
+++ b/tests/core/test_auth.py
@@ -1,39 +1,43 @@
+import json
+
+import eth_keyfile
+from eth_utils import to_text
 import pytest
 
-from ethpm_cli.auth import get_authorized_address, get_authorized_private_key
-from ethpm_cli.constants import PRIVATE_KEY_ENV_VAR
+from ethpm_cli.auth import (
+    get_authorized_address,
+    get_authorized_private_key,
+    validate_keyfile_path_and_password,
+)
+from ethpm_cli.constants import KEYFILE_PASSWORD, KEYFILE_PATH
+from ethpm_cli.exceptions import ValidationError
 
-PRIVATE_KEY = "b1febf5283d3514c7bc5be3ce6b034d227c8159e85bb6e958181cd09525ce5b9"
-ADDRESS = "0xabc4FC248969137A5078DE7b685C4E7f7AC3Be26"
+PRIVATE_KEY = b"\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"  # noqa: E501
+ADDRESS = "0x1a642f0E3c3aF545E7AcBD38b07251B3990914F1"
+PASSWORD = b"password"
+KEYFILE_JSON = eth_keyfile.create_keyfile_json(PRIVATE_KEY, PASSWORD)
 
 
-def test_get_auth_private_key(monkeypatch):
-    monkeypatch.setenv(PRIVATE_KEY_ENV_VAR, PRIVATE_KEY)
+@pytest.fixture
+def keyfile(monkeypatch, tmp_path):
+    tmp_keyfile = tmp_path / "keyfile.json"
+    tmp_keyfile.touch()
+    tmp_keyfile.write_text(json.dumps(KEYFILE_JSON))
+    monkeypatch.setenv(KEYFILE_PASSWORD, to_text(PASSWORD))
+    monkeypatch.setenv(KEYFILE_PATH, str(tmp_keyfile))
+    return tmp_keyfile
+
+
+def test_get_auth_private_key(keyfile):
     actual_priv_key = get_authorized_private_key()
     assert actual_priv_key == PRIVATE_KEY
 
 
-@pytest.mark.parametrize(
-    "key",
-    (
-        1,
-        {},
-        None,
-        True,
-        "xxx",
-        # 63 chars
-        "000000000000000000000000000000000000000000000000000000000000000",
-        # 65 chars
-        "00000000000000000000000000000000000000000000000000000000000000000",
-    ),
-)
-def test_get_auth_private_key_raises_exception_with_invalid_key(key, monkeypatch):
-    monkeypatch.setenv(PRIVATE_KEY_ENV_VAR, key)
-    with pytest.raises(Exception, match="is not a valid private key."):
-        get_authorized_private_key()
-
-
-def test_get_authorized_address(monkeypatch):
-    monkeypatch.setenv(PRIVATE_KEY_ENV_VAR, PRIVATE_KEY)
+def test_get_authorized_address(keyfile):
     auth_address = get_authorized_address()
     assert auth_address == ADDRESS
+
+
+def test_validate_keyfile_path_and_password(keyfile):
+    with pytest.raises(ValidationError, match="Invalid keyfile password."):
+        validate_keyfile_path_and_password(str(keyfile), b"invalid")

--- a/tests/core/test_auth.py
+++ b/tests/core/test_auth.py
@@ -1,13 +1,17 @@
+from pathlib import Path
+import tempfile
+import filecmp
 import json
+import os
 
 import eth_keyfile
-from eth_utils import to_text
+from eth_utils import is_same_address, to_text
 import pytest
 
 from ethpm_cli.auth import (
     get_authorized_address,
     get_authorized_private_key,
-    validate_keyfile_path_and_password,
+    import_keyfile,
 )
 from ethpm_cli.constants import KEYFILE_PASSWORD, KEYFILE_PATH
 from ethpm_cli.exceptions import ValidationError
@@ -19,25 +23,29 @@ KEYFILE_JSON = eth_keyfile.create_keyfile_json(PRIVATE_KEY, PASSWORD)
 
 
 @pytest.fixture
-def keyfile(monkeypatch, tmp_path):
-    tmp_keyfile = tmp_path / "keyfile.json"
+def keyfile(monkeypatch, tmpdir):
+    monkeypatch.chdir(tmpdir)
+    ethpmcli_dir = Path(tmpdir / "ethpmcli_dir")
+    ethpmcli_dir.mkdir()
+    monkeypatch.setenv("XDG_ETHPMCLI_ROOT", str(ethpmcli_dir))
+    tmp_keyfile = ethpmcli_dir / KEYFILE_PATH
     tmp_keyfile.touch()
     tmp_keyfile.write_text(json.dumps(KEYFILE_JSON))
-    monkeypatch.setenv(KEYFILE_PASSWORD, to_text(PASSWORD))
-    monkeypatch.setenv(KEYFILE_PATH, str(tmp_keyfile))
     return tmp_keyfile
 
 
-def test_get_auth_private_key(keyfile):
-    actual_priv_key = get_authorized_private_key()
-    assert actual_priv_key == PRIVATE_KEY
+def test_import_keyfile(keyfile):
+    # is this even testing anything useful?
+    ethpmcli_dir = Path(os.environ["XDG_ETHPMCLI_ROOT"])
+    import_keyfile(keyfile)
+    assert filecmp.cmp(ethpmcli_dir / KEYFILE_PATH, keyfile)
 
 
 def test_get_authorized_address(keyfile):
     auth_address = get_authorized_address()
-    assert auth_address == ADDRESS
+    assert is_same_address(auth_address, ADDRESS)
 
 
-def test_validate_keyfile_path_and_password(keyfile):
-    with pytest.raises(ValidationError, match="Invalid keyfile password."):
-        validate_keyfile_path_and_password(str(keyfile), b"invalid")
+def test_get_authorized_private_key(keyfile):
+    actual_priv_key = get_authorized_private_key(to_text(PASSWORD))
+    assert actual_priv_key == PRIVATE_KEY

--- a/tests/core/test_auth.py
+++ b/tests/core/test_auth.py
@@ -1,35 +1,16 @@
 import filecmp
-import json
 import os
 from pathlib import Path
 
-import eth_keyfile
 from eth_utils import is_same_address, to_text
-import pytest
 
 from ethpm_cli.auth import (
     get_authorized_address,
     get_authorized_private_key,
+    get_keyfile_path,
     import_keyfile,
 )
 from ethpm_cli.constants import KEYFILE_PATH
-
-PRIVATE_KEY = b"\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"  # noqa: E501
-ADDRESS = "0x1a642f0E3c3aF545E7AcBD38b07251B3990914F1"
-PASSWORD = b"password"
-KEYFILE_JSON = eth_keyfile.create_keyfile_json(PRIVATE_KEY, PASSWORD)
-
-
-@pytest.fixture
-def keyfile(monkeypatch, tmpdir):
-    monkeypatch.chdir(tmpdir)
-    ethpmcli_dir = Path(tmpdir / "ethpmcli_dir")
-    ethpmcli_dir.mkdir()
-    monkeypatch.setenv("XDG_ETHPMCLI_ROOT", str(ethpmcli_dir))
-    tmp_keyfile = ethpmcli_dir / KEYFILE_PATH
-    tmp_keyfile.touch()
-    tmp_keyfile.write_text(json.dumps(KEYFILE_JSON))
-    return tmp_keyfile
 
 
 def test_import_keyfile(keyfile):
@@ -38,11 +19,18 @@ def test_import_keyfile(keyfile):
     assert filecmp.cmp(ethpmcli_dir / KEYFILE_PATH, keyfile)
 
 
-def test_get_authorized_address(keyfile):
-    auth_address = get_authorized_address()
-    assert is_same_address(auth_address, ADDRESS)
+def test_get_authorized_address(keyfile, keyfile_auth):
+    _, expected_address, _ = keyfile_auth
+    actual_address = get_authorized_address()
+    assert is_same_address(actual_address, expected_address)
 
 
-def test_get_authorized_private_key(keyfile):
-    actual_priv_key = get_authorized_private_key(to_text(PASSWORD))
-    assert actual_priv_key == PRIVATE_KEY
+def test_get_authorized_private_key(keyfile, keyfile_auth):
+    expected_private_key, _, password = keyfile_auth
+    actual_priv_key = get_authorized_private_key(to_text(password))
+    assert actual_priv_key == expected_private_key
+
+
+def test_keyfile_fixture_exposes_tmp_dirs_not_user_dirs(keyfile):
+    path = get_keyfile_path()
+    assert "pytest" in str(path)

--- a/tests/core/test_install.py
+++ b/tests/core/test_install.py
@@ -1,6 +1,4 @@
-from argparse import Namespace
 import logging
-from pathlib import Path
 
 import pytest
 
@@ -8,7 +6,6 @@ from ethpm_cli._utils.testing import check_dir_trees_equal
 from ethpm_cli.constants import ETHPM_DIR_NAME
 from ethpm_cli.exceptions import InstallError
 from ethpm_cli.install import (
-    Config,
     install_package,
     list_installed_packages,
     uninstall_package,

--- a/tests/core/test_install.py
+++ b/tests/core/test_install.py
@@ -17,18 +17,6 @@ from ethpm_cli.package import Package
 
 
 @pytest.fixture
-def config(tmpdir):
-    namespace = Namespace()
-    ethpm_dir = Path(tmpdir) / ETHPM_DIR_NAME
-    ethpm_dir.mkdir()
-    namespace.local_ipfs = False
-    namespace.install_uri = None
-    namespace.alias = None
-    namespace.ethpm_dir = ethpm_dir
-    return Config(namespace)
-
-
-@pytest.fixture
 def owned_pkg(config):
     return Package(
         "ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW",


### PR DESCRIPTION
## What was wrong?
Creates a command to use a password-protected keyfile for auth purposes.

Set environment variables via.
```
ethpm auth <path_to_keyfile> <password>
```

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/61082030-3f3cbd80-a3ee-11e9-89ec-4d75f5f93c79.png)

