### PR TITLE
Write rtd config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,6 @@
+build:
+  image: latest
+
+python:
+  extra_requirements:
+    - doc

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,9 +31,6 @@ with open (os.path.join(DIR, '../setup.py'), 'r') as f:
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
 
-# Mock import
-autodoc_mock_imports = ['sphinx-argparse']
-
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.


### PR DESCRIPTION
## What was wrong?
RTD isn't installing the `doc` dependencies from `setup.py` / `extras_require`. This config file should fix that.

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/62176495-0150fc00-b2ff-11e9-8ec1-0511ccbc7c6d.png)
