### PR TITLE
Remove unnecessary ethpmdir flag from release command

### DIFF
--- a/ethpm_cli/parser.py
+++ b/ethpm_cli/parser.py
@@ -144,7 +144,6 @@ release_parser.add_argument(
     type=str,
     help="Content addressed URI at which the manifest for released package is located.",
 )
-add_ethpm_dir_arg_to_parser(release_parser)
 add_keyfile_password_arg_to_parser(release_parser)
 release_parser.set_defaults(func=release_cmd)
 


### PR DESCRIPTION
## What was wrong?
Unnecessary flag

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/63359979-dfa9ca00-c32a-11e9-9548-dff11c804b3d.png)

