### PR TITLE
Update manifest to grab sources for Interface contracts

### DIFF
--- a/docs/uris.rst
+++ b/docs/uris.rst
@@ -11,6 +11,7 @@ ethPM Cli supports the following URI schemes.
 
   - ``etherscan://[CONTRACT_ADDRESS]:[CHAIN_ID]``
   - ``CONTRACT_ADDRESS`` and ``CHAIN_ID`` must represent a `Verified Contract <https://etherscan.io/contractsVerified>`_ on Etherscan.
+  - ``CONTRACT_ADDRESS`` **MUST** be a valid, checksummed address.
   - Supported values for ``CHAIN_ID``
 
       ========  ===== 

--- a/ethpm_cli/_utils/solc.py
+++ b/ethpm_cli/_utils/solc.py
@@ -108,6 +108,10 @@ def get_contract_types_and_sources(
 ) -> Iterable[Tuple[str, Iterable[Path]]]:
     for source in solc_output:
         for ctype, data in solc_output[source].items():
-            metadata = json.loads(data["metadata"])
-            sources = tuple(Path(src) for src in metadata["sources"].keys())
-            yield ctype, sources
+            if data["metadata"]:
+                metadata = json.loads(data["metadata"])
+                sources = tuple(Path(src) for src in metadata["sources"].keys())
+                yield ctype, sources
+            # For Interface contracts w/ empty metadata['sources']
+            else:
+                yield ctype, (Path(source),)

--- a/ethpm_cli/manifest.py
+++ b/ethpm_cli/manifest.py
@@ -19,7 +19,6 @@ from ethpm_cli._utils.solc import (
     get_contract_types,
     get_contract_types_and_sources,
 )
-from ethpm_cli._utils.various import flatten
 from ethpm_cli.config import setup_w3
 from ethpm_cli.constants import SOLC_OUTPUT
 from ethpm_cli.validation import validate_solc_output
@@ -122,31 +121,20 @@ def gen_contract_types_and_sources(
             else:
                 break
 
-    # get target sources associated with target contract types
     inline_source_flag = parse_bool_flag(
         "Would you like to inline source files? If not, sources will "
         "be automatically pinned to IPFS."
     )
-    target_sources = set(
-        flatten(
-            [
-                sources
-                for ctype, sources in ctypes_and_sources
-                if ctype in target_contract_types
-            ]
-        )
-    )
-    target_source_names = tuple(src.stem for src in target_sources)
 
-    # generate contract types and sources builder fns for manfiest builder
+    # generate contract types and sources builder fns for manifest builder
     generated_contract_types = build_contract_types(target_contract_types, solc_output)
     if inline_source_flag:
         generated_sources = build_inline_sources(
-            target_source_names, solc_output, contracts_dir
+            target_contract_types, solc_output, contracts_dir
         )
     else:
         generated_sources = build_pinned_sources(
-            target_source_names, solc_output, contracts_dir
+            target_contract_types, solc_output, contracts_dir
         )
     return ((*generated_contract_types), (*generated_sources))
 


### PR DESCRIPTION
## What was wrong?
Solidity compiler doesn't generate `[metadata][sources]` for interface contracts, so this fix was needed to grab an Interface contract's source.

### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/63719696-c01f0f80-c80a-11e9-8f55-1093ae9b6253.png)

