### PR TITLE
Implement ethpm activate

### DIFF
--- a/ethpm_cli/commands/activate.py
+++ b/ethpm_cli/commands/activate.py
@@ -1,0 +1,126 @@
+from argparse import Namespace
+import json
+from urllib import parse
+
+from IPython import embed
+from eth_utils import to_dict, to_hex
+from ethpm import Package as ethpmPackage
+from ethpm.exceptions import InsufficientAssetsError
+from ethpm.uri import check_if_chain_matches_chain_uri
+from web3.auto.infura.goerli import w3 as goerli_w3
+from web3.auto.infura.kovan import w3 as kovan_w3
+from web3.auto.infura.mainnet import w3 as mainnet_w3
+from web3.auto.infura.rinkeby import w3 as rinkeby_w3
+from web3.auto.infura.ropsten import w3 as ropsten_w3
+
+from ethpm_cli._utils.filesystem import is_package_installed
+from ethpm_cli._utils.logger import cli_logger
+from ethpm_cli.commands.package import Package
+from ethpm_cli.config import Config
+from ethpm_cli.exceptions import InstallError, UriNotSupportedError
+
+SUPPORTED_SCHEMES = ["http", "https", "ipfs", "etherscan", "erc1319"]
+
+SUPPORTED_GENESIS_HASHES = {
+    "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3": "mainnet",
+    "0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d": "ropsten",
+    "0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177": "rinkeby",
+    "0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a": "goerli",
+    "0xa3c565fc15c7478862d50ccd6561e3c06b24cc509bf388941c25ea985ce32cb9": "kovan",
+}
+
+
+def activate_package(args: Namespace, config: Config) -> None:
+    # support: etherscan / ipfs / github / erc1319
+    url = parse.urlparse(args.package_or_uri)
+    if url.scheme:
+        if url.scheme not in SUPPORTED_SCHEMES:
+            raise UriNotSupportedError(
+                f"URIs with a scheme of {url.scheme} are not supported. "
+                f"Currently supported schemes include: {SUPPORTED_SCHEMES}"
+            )
+        try:
+            args.package_name = "etherscan"  # for etherscan URIs
+            args.package_version = "1.0.0"  # for etherscan URIs
+            args.uri = args.package_or_uri
+            pkg = Package(args, config.ipfs_backend)
+            manifest = pkg.manifest
+        except UriNotSupportedError:
+            raise UriNotSupportedError(
+                f"{args.package_or_uri} is not a supported URI. The only URIs currently supported "
+                "are Registry, Github Blob, Etherscan and IPFS"
+            )
+    else:
+        if not is_package_installed(args.package_or_uri, config):
+            raise InstallError(
+                f"Package: {args.package_or_uri} not installed in ethPM dir: {config.ethpm_dir}."
+            )
+        manifest = json.loads(
+            (config.ethpm_dir / args.package_or_uri / "manifest.json").read_text()
+        )
+
+    pkg = ethpmPackage(manifest, config.w3)
+    cli_logger.info(f"Activating package: {pkg.name}")
+
+    try:
+        cli_logger.info(f"Found {len(pkg.contract_types)} contract types.")
+        available_factories = generate_contract_factories(pkg)
+    except ValueError:
+        cli_logger.info(f"No contract types found.\n")
+        available_factories = {}
+
+    if "deployments" in pkg.manifest:
+        available_deployments = generate_deployments(pkg)
+    else:
+        cli_logger.info(f"No deployments found.\n")
+        available_deployments = {}
+
+    # instantiate contract factory variables
+    if len(available_factories) > 0:
+        cli_logger.info("Available contract factories: ")
+        for key, val in available_factories.items():
+            cli_logger.info(f"- {key}_factory")
+            exec(f"{key}_factory" + "=val")
+
+    # instantiate contract instance variables
+    if len(available_deployments) > 0:
+        cli_logger.info("Available deployments: ")
+        for key, val in available_deployments.items():
+            cli_logger.info(f"- {key}")
+            exec(f"{key}" + "=val")
+
+    cli_logger.info("Starting IPython console...\n")
+    embed(colors="neutral")
+
+
+@to_dict
+def generate_contract_factories(pkg: ethpmPackage):
+    for ctype in pkg.contract_types:
+        try:
+            factory = pkg.get_contract_factory(ctype)
+            yield ctype, factory
+        except InsufficientAssetsError:
+            cli_logger.info(
+                f"Insufficient assets to generate factory for {ctype}. Package must contain the "
+                "abi & deployment bytecode to be able to generate a factory."
+            )
+
+
+@to_dict
+def generate_deployments(pkg: ethpmPackage):
+    cli_logger.info(f"Found deployments...")
+    for chain in pkg.manifest["deployments"]:
+        w3, chain_name = get_matching_w3(chain)
+        new_pkg = pkg.update_w3(w3)
+        for dep in pkg.manifest["deployments"][chain].keys():
+            yield f"{chain_name}_{dep}", new_pkg.deployments.get_instance(dep)
+
+
+def get_matching_w3(chain_uri):
+    all_w3s = [mainnet_w3, kovan_w3, ropsten_w3, rinkeby_w3, goerli_w3]
+    for w3 in all_w3s:
+        if check_if_chain_matches_chain_uri(w3, chain_uri):
+            genesis = w3.eth.getBlock(0)
+            chain_name = SUPPORTED_GENESIS_HASHES[to_hex(genesis["hash"])]
+            return w3, chain_name
+    raise InstallError(f"No valid web3 found for deployment on chain: {chain_uri}.")

--- a/ethpm_cli/parser.py
+++ b/ethpm_cli/parser.py
@@ -622,4 +622,5 @@ activate_parser.add_argument(
     help="Installed package or URI of package to activate.",
 )
 add_ethpm_dir_arg_to_parser(activate_parser)
+add_keyfile_password_arg_to_parser(activate_parser)
 activate_parser.set_defaults(func=activate_action, pretty=False)

--- a/ethpm_cli/parser.py
+++ b/ethpm_cli/parser.py
@@ -7,6 +7,7 @@ from ethpm.constants import SUPPORTED_CHAIN_IDS
 from ethpm_cli._utils.logger import cli_logger
 from ethpm_cli._utils.solc import compile_contracts, generate_solc_input
 from ethpm_cli._utils.xdg import get_xdg_ethpmcli_root
+from ethpm_cli.commands.activate import activate_package
 from ethpm_cli.commands.auth import get_authorized_address
 from ethpm_cli.commands.get import get_manifest
 from ethpm_cli.commands.install import (
@@ -486,13 +487,14 @@ def update_action(args: argparse.Namespace) -> None:
 
 
 update_parser = ethpm_parser.add_parser(
-    "update", help="Update a package to a new release available on active registry."
+    "update",
+    help="Update / revert a package to a different release available on active registry.",
 )
 update_parser.add_argument(
     "package",
     action="store",
     type=str,
-    help="Package name / alias of target package to uninstall.",
+    help="Package name / alias of target package to update.",
 )
 add_ethpm_dir_arg_to_parser(update_parser)
 update_parser.set_defaults(func=update_action)
@@ -598,3 +600,26 @@ get_group.add_argument(
     help="Pretty print the resolved manifest JSON.",
 )
 get_parser.set_defaults(func=get_action, pretty=False)
+
+
+#
+# ethpm activate
+#
+
+
+def activate_action(args: argparse.Namespace) -> None:
+    config = Config(args)
+    activate_package(args, config)
+
+
+activate_parser = ethpm_parser.add_parser(
+    "activate", help="Activate a package and launch in local console.",
+)
+activate_parser.add_argument(
+    "package_or_uri",
+    action="store",
+    type=str,
+    help="Installed package or URI of package to activate.",
+)
+add_ethpm_dir_arg_to_parser(activate_parser)
+activate_parser.set_defaults(func=activate_action, pretty=False)

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-hash[pysha3]>=0.2.0,<1",
-        "ipython",
+        "ipython>=7.11.1,<8",
         "requests>=2.22.0,<3",
         "web3[tester]>=5.0.1,<6",
     ],

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ extras_require = {
         "pytest-watch>=4.1.0,<5",
         "wheel",
         "twine",
-        "ipython",
     ],
 }
 
@@ -52,6 +51,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-hash[pysha3]>=0.2.0,<1",
+        "ipython",
         "requests>=2.22.0,<3",
         "web3[tester]>=5.0.1,<6",
     ],

--- a/tests/cli/test_activate.py
+++ b/tests/cli/test_activate.py
@@ -1,0 +1,143 @@
+import pexpect
+
+from ethpm_cli.constants import ETHPM_CLI_VERSION
+
+
+def test_activate_with_uninstalled_package(test_assets_dir):
+    ethpm_dir = test_assets_dir / "owned" / "ipfs_uri" / "_ethpm_packages"
+    child = pexpect.spawn(f"ethpm activate invalid --ethpm-dir {ethpm_dir}", timeout=15)
+    child.expect(f"ethPM CLI v{ETHPM_CLI_VERSION}\r\n")
+    child.expect("\r\n")
+    child.expect(f"Package: invalid not installed in ethPM dir: {ethpm_dir}")
+    child.close()
+
+
+def test_activate_with_invalid_uri():
+    child = pexpect.spawn(f"ethpm activate http://www.google.com", timeout=15)
+    child.expect(f"ethPM CLI v{ETHPM_CLI_VERSION}\r\n")
+    child.expect("\r\n")
+    child.expect(
+        f"http://www.google.com is not a supported URI. The only URIs currently supported "
+        "are Registry, Github Blob, Etherscan and IPFS"
+    )
+    child.close()
+
+
+def test_activate_locally_installed_pkg_without_contract_types(test_assets_dir):
+    child = pexpect.spawn(
+        "ethpm activate owned --ethpm-dir "
+        f"{test_assets_dir / 'owned' / 'ipfs_uri' / '_ethpm_packages'}",
+        timeout=15,
+    )
+    child.expect(f"ethPM CLI v{ETHPM_CLI_VERSION}\r\n")
+    child.expect("\r\n")
+    child.expect("Activating package: owned")
+    child.expect("No contract types found.")
+    child.expect("No deployments found.")
+    child.close()
+
+
+def test_activate_with_aliased_locally_installed_pkg(test_assets_dir):
+    child = pexpect.spawn(
+        "ethpm activate owned-alias --ethpm-dir "
+        f"{test_assets_dir / 'owned' / 'ipfs_uri_alias' / '_ethpm_packages'}",
+        timeout=15,
+    )
+    child.expect(f"ethPM CLI v{ETHPM_CLI_VERSION}\r\n")
+    child.expect("\r\n")
+    child.expect("Activating package: owned")
+    child.expect("No contract types found.")
+    child.expect("No deployments found.")
+    child.close()
+
+
+def test_activate_etherscan_uri_with_single_deployment():
+    child = pexpect.spawn(
+        f"ethpm activate etherscan://0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359:1",
+        timeout=30,
+    )
+    child.expect(f"ethPM CLI v{ETHPM_CLI_VERSION}\r\n")
+    child.expect("\r\n")
+    child.expect("Activating package: etherscan")
+    child.expect("Found 1 contract types.")
+    child.expect(
+        "Insufficient assets to generate factory for DSToken. Package must contain "
+        "the abi & deployment bytecode to be able to generate a factory."
+    )
+    child.expect("Found deployments...")
+    child.expect("Available deployments:")
+    child.expect("- mainnet_DSToken")
+    child.expect("Starting IPython console...")
+    # test deployment is available
+    child.sendline("mainnet_DSToken")
+    child.expect("web3._utils.datatypes.LinkableContract at")
+    child.close()
+
+
+def test_activate_ipfs_uri_with_factories_and_deployments():
+    child = pexpect.spawn(
+        f"ethpm activate ipfs://Qmf5uJd3yChPwxYxHqR1KN2CdXt2pfsAfPzQe8gkNutwT3",
+        timeout=30,
+    )
+    child.expect(f"ethPM CLI v{ETHPM_CLI_VERSION}\r\n")
+    child.expect("\r\n")
+    child.expect("Activating package: ethregistrar")
+    child.expect("Found 29 contract types.")
+    child.expect("Found deployments...")
+    child.expect("Available contract factories:")
+    child.expect("- Address_factory")
+    child.expect("- BaseRegistrar_factory")
+    child.expect("Available deployments:")
+    child.expect("- mainnet_BaseRegistrarImplementation")
+    child.expect("Starting IPython console...")
+    # test contract factory is available
+    child.sendline("Address_factory")
+    child.expect("web3._utils.datatypes.LinkableContract")
+    # test deployment is available
+    child.sendline("mainnet_BaseRegistrarImplementation")
+    child.expect("web3._utils.datatypes.LinkableContract at")
+    child.close()
+
+
+def test_activate_github_uri_with_insufficient_contract_types_and_deployments():
+    child = pexpect.spawn(
+        "ethpm activate https://api.github.com/repos/"
+        "ethpm/ethpm-cli/git/blobs/9fb9a7ec579932d251967c3c6b57f543c1909788",
+        timeout=30,
+    )
+    child.expect(f"ethPM CLI v{ETHPM_CLI_VERSION}\r\n")
+    child.expect("\r\n")
+    child.expect("Activating package: dai")
+    child.expect("Found 1 contract types.")
+    child.expect(
+        "Insufficient assets to generate factory for DSToken. Package must contain "
+        "the abi & deployment bytecode to be able to generate a factory."
+    )
+    child.expect("Found deployments...")
+    child.expect("Available deployments:")
+    child.expect("- mainnet_DSToken")
+    child.expect("Starting IPython console...")
+    # test deployment is available
+    child.sendline("mainnet_DSToken")
+    child.expect("web3._utils.datatypes.LinkableContract at")
+    child.close()
+
+
+def test_activate_registry_uri_with_contract_types_no_deployments():
+    child = pexpect.spawn(
+        f"ethpm activate erc1319://ens.snakecharmers.eth:1/ens?version=1.0.0",
+        timeout=30,
+    )
+    child.expect(f"ethPM CLI v{ETHPM_CLI_VERSION}\r\n")
+    child.expect("\r\n")
+    child.expect("Activating package: ens")
+    child.expect("Found 10 contract types.")
+    child.expect("No deployments found.")
+    child.expect("Available contract factories:")
+    child.expect("- Deed_factory")
+    child.expect("- DeedImplementation_factory")
+    child.expect("Starting IPython console...")
+    # test contract factory is available
+    child.sendline("Deed_factory")
+    child.expect("web3._utils.datatypes.LinkableContract")
+    child.close()

--- a/tests/cli/test_activate.py
+++ b/tests/cli/test_activate.py
@@ -32,8 +32,8 @@ def test_activate_locally_installed_pkg_without_contract_types(test_assets_dir):
     child.expect(f"ethPM CLI v{ETHPM_CLI_VERSION}\r\n")
     child.expect("\r\n")
     child.expect("Activating package: owned")
-    child.expect("No contract types found.")
-    child.expect("No deployments found.")
+    child.expect("No detected contract types.")
+    child.expect("No detected deployments.")
     child.close()
 
 
@@ -46,8 +46,8 @@ def test_activate_with_aliased_locally_installed_pkg(test_assets_dir):
     child.expect(f"ethPM CLI v{ETHPM_CLI_VERSION}\r\n")
     child.expect("\r\n")
     child.expect("Activating package: owned")
-    child.expect("No contract types found.")
-    child.expect("No deployments found.")
+    child.expect("No detected contract types.")
+    child.expect("No detected deployments.")
     child.close()
 
 
@@ -58,19 +58,26 @@ def test_activate_etherscan_uri_with_single_deployment():
     )
     child.expect(f"ethPM CLI v{ETHPM_CLI_VERSION}\r\n")
     child.expect("\r\n")
-    child.expect("Activating package: etherscan")
-    child.expect("Found 1 contract types.")
+    child.expect("Activating package: etherscan@1.0.0")
+    child.expect("Insufficient assets to generate factory for DSToken")
     child.expect(
-        "Insufficient assets to generate factory for DSToken. Package must contain "
-        "the abi & deployment bytecode to be able to generate a factory."
+        "Successfully generated 1 contract instance from 1 detected deployment."
     )
-    child.expect("Found deployments...")
-    child.expect("Available deployments:")
     child.expect("- mainnet_DSToken")
+    child.expect("Available Web3 Instances")
+    child.expect(
+        "Contract instances and web3 instances have not been configured with an account."
+    )
+    child.expect(
+        "The API for web3.py contract factories and instances can be found here:"
+    )
     child.expect("Starting IPython console...")
     # test deployment is available
     child.sendline("mainnet_DSToken")
     child.expect("web3._utils.datatypes.LinkableContract at")
+    # test w3 is available
+    child.sendline("mainnet_w3")
+    child.expect("web3.main.Web3 at")
     child.close()
 
 
@@ -82,13 +89,23 @@ def test_activate_ipfs_uri_with_factories_and_deployments():
     child.expect(f"ethPM CLI v{ETHPM_CLI_VERSION}\r\n")
     child.expect("\r\n")
     child.expect("Activating package: ethregistrar")
-    child.expect("Found 29 contract types.")
-    child.expect("Found deployments...")
-    child.expect("Available contract factories:")
+    child.expect(
+        "Successfully generated 29 contract factories on mainnet from 29 detected contract types."
+    )
     child.expect("- Address_factory")
     child.expect("- BaseRegistrar_factory")
-    child.expect("Available deployments:")
+    child.expect("To get a contract factory on a different chain,")
+    child.expect(
+        "Successfully generated 1 contract instance from 1 detected deployment."
+    )
     child.expect("- mainnet_BaseRegistrarImplementation")
+    child.expect("Available Web3 Instances")
+    child.expect(
+        "Contract instances and web3 instances have not been configured with an account."
+    )
+    child.expect(
+        "The API for web3.py contract factories and instances can be found here:"
+    )
     child.expect("Starting IPython console...")
     # test contract factory is available
     child.sendline("Address_factory")
@@ -108,14 +125,18 @@ def test_activate_github_uri_with_insufficient_contract_types_and_deployments():
     child.expect(f"ethPM CLI v{ETHPM_CLI_VERSION}\r\n")
     child.expect("\r\n")
     child.expect("Activating package: dai")
-    child.expect("Found 1 contract types.")
+    child.expect("Insufficient assets to generate factory for DSToken.")
     child.expect(
-        "Insufficient assets to generate factory for DSToken. Package must contain "
-        "the abi & deployment bytecode to be able to generate a factory."
+        "Successfully generated 1 contract instance from 1 detected deployment."
     )
-    child.expect("Found deployments...")
-    child.expect("Available deployments:")
     child.expect("- mainnet_DSToken")
+    child.expect("Available Web3 Instances")
+    child.expect(
+        "Contract instances and web3 instances have not been configured with an account."
+    )
+    child.expect(
+        "The API for web3.py contract factories and instances can be found here:"
+    )
     child.expect("Starting IPython console...")
     # test deployment is available
     child.sendline("mainnet_DSToken")
@@ -131,11 +152,14 @@ def test_activate_registry_uri_with_contract_types_no_deployments():
     child.expect(f"ethPM CLI v{ETHPM_CLI_VERSION}\r\n")
     child.expect("\r\n")
     child.expect("Activating package: ens")
-    child.expect("Found 10 contract types.")
-    child.expect("No deployments found.")
-    child.expect("Available contract factories:")
+    child.expect(
+        "Successfully generated 10 contract factories on mainnet from 10 detected contract types."
+    )
     child.expect("- Deed_factory")
     child.expect("- DeedImplementation_factory")
+    child.expect("To get a contract factory on a different chain,")
+    child.expect("No detected deployments.")
+    child.expect("Available Web3 Instances")
     child.expect("Starting IPython console...")
     # test contract factory is available
     child.sendline("Deed_factory")


### PR DESCRIPTION
## What was wrong?
`ethpm activate [installed_package_name or uri]` command to make it super duper simple to interact with any package in your terminal.

Automatically opens up an ipython console with all contract factories and deployments found in the package loaded and ready to use.

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/73281794-c4ec5300-41f0-11ea-8db7-3e85e6ec8f60.png)

