### PR TITLE
Update web3 version and fix broken tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "ipython>=7.11.1,<8",
         "requests>=2.22.0,<3",
         "termcolor>=1.1.0,<2.0.0",
-        "web3[tester]>=5.4.0,<6",
+        "web3[tester]>=5.5.0,<6",
     ],
     setup_requires=['setuptools-markdown'],
     python_requires='>=3.7, <4',

--- a/tests/cli/test_activate.py
+++ b/tests/cli/test_activate.py
@@ -156,8 +156,7 @@ def test_activate_github_uri_with_insufficient_contract_types_and_deployments():
 
 def test_activate_registry_uri_with_contract_types_no_deployments():
     child = pexpect.spawn(
-        f"ethpm activate erc1319://ens.snakecharmers.eth:1/ens?version=1.0.0",
-        timeout=30,
+        f"ethpm activate erc1319://ens.snakecharmers.eth:1/ens@1.0.0", timeout=30,
     )
     child.expect(ENTRY_DESCRIPTION)
     child.expect("\r\n")

--- a/tests/core/assets/owned/registry_uri/_ethpm_packages/ethpm.lock
+++ b/tests/core/assets/owned/registry_uri/_ethpm_packages/ethpm.lock
@@ -1,7 +1,7 @@
 {
     "owned": {
         "alias": "owned",
-        "install_uri": "erc1319://0x1457890158DECD360e6d4d979edBcDD59c35feeB:1/owned?version=1.0.0",
+        "install_uri": "erc1319://0x1457890158DECD360e6d4d979edBcDD59c35feeB:1/owned@1.0.0",
         "registry_address": "0x1457890158DECD360e6d4d979edBcDD59c35feeB",
         "resolved_content_hash": "QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW",
         "resolved_package_name": "owned",

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -14,6 +14,6 @@ def owned_pkg_data(test_assets_dir):
         "manifest": json.loads(owned_raw_manifest),
         "ipfs_uri": "ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW",
         "content_hash": "QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW",
-        "registry_uri": "erc1319://0x1457890158DECD360e6d4d979edBcDD59c35feeB:1/owned?version=1.0.0",  # noqa: E501
+        "registry_uri": "erc1319://0x1457890158DECD360e6d4d979edBcDD59c35feeB:1/owned@1.0.0",
         "registry_address": "0x1457890158DECD360e6d4d979edBcDD59c35feeB",
     }

--- a/tests/core/test_install.py
+++ b/tests/core/test_install.py
@@ -44,7 +44,7 @@ def wallet_pkg(config):
         ),
         (
             Namespace(
-                uri="erc1319://0x1457890158DECD360e6d4d979edBcDD59c35feeB:1/owned?version=1.0.0"
+                uri="erc1319://0x1457890158DECD360e6d4d979edBcDD59c35feeB:1/owned@1.0.0"
             ),
             "owned",
             "registry_uri",
@@ -65,7 +65,7 @@ def test_install_package(args, pkg_name, install_type, config, test_assets_dir):
 
 
 def test_install_package_with_ens_in_registry_uri(config):
-    uri = Namespace(uri="erc1319://ens.snakecharmers.eth:1/ens?version=1.0.0")
+    uri = Namespace(uri="erc1319://ens.snakecharmers.eth:1/ens@1.0.0")
     pkg = Package(uri, config.ipfs_backend)
     install_package(pkg, config)
 


### PR DESCRIPTION
## What was wrong?
Latest update to `ethpm` module in `web3` updated the registry uri definition - which broke some tests here.

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/73842082-2d07ee00-481c-11ea-91a0-2f0b394e2625.png)

