### PR TITLE
Separate auth command into more useful subparsers

### DIFF
--- a/ethpm_cli/_utils/input.py
+++ b/ethpm_cli/_utils/input.py
@@ -1,0 +1,13 @@
+from ethpm_cli._utils.logger import cli_logger
+
+
+def parse_bool_flag(question: str) -> bool:
+    while True:
+        response = input(f"{question} (y/n) ")
+        if response.lower() == "y":
+            return True
+        elif response.lower() == "n":
+            return False
+        else:
+            cli_logger.info(f"Invalid response: {response}.")
+            continue

--- a/ethpm_cli/commands/auth.py
+++ b/ethpm_cli/commands/auth.py
@@ -1,23 +1,104 @@
+import json
 from pathlib import Path
-import tempfile
 from typing import Any, Dict
 
 import eth_keyfile
 from eth_typing import Address
-from eth_utils import to_bytes
+from eth_utils import add_0x_prefix, to_bytes
 
+from ethpm_cli._utils.filesystem import atomic_replace
+from ethpm_cli._utils.input import parse_bool_flag
+from ethpm_cli._utils.logger import cli_logger
 from ethpm_cli._utils.xdg import get_xdg_ethpmcli_root
 from ethpm_cli.constants import KEYFILE_PATH
 from ethpm_cli.exceptions import AuthorizationError
+
+PRIVATE_KEY_WARNING = (
+    "Please be careful when using your private key, it is a sensitive piece of information.\n",
+    "~ ~ ~ Not your keys, not your crypto. ~ ~ ~\n",
+    "ethPM doesn't save your private key, but it is best practice to re-use an already encrypted ",
+    "keyfile and link it with `ethpm auth link` rather than regenerating a new encrypted keyfile.",
+)
+
+
+def link_keyfile(keyfile_path: Path) -> None:
+    if valid_keyfile_exists():
+        xdg_keyfile = get_keyfile_path()
+        cli_logger.info(
+            f"Keyfile detected at {xdg_keyfile}. Please use `ethpm auth unlink` to delete this "
+            "keyfile before linking a new one."
+        )
+    else:
+        import_keyfile(keyfile_path)
+        address = get_authorized_address()
+        cli_logger.info(
+            f"Keyfile stored for address: {address}\n"
+            "It's now available for use when its password is passed in with the "
+            "`--keyfile-password` flag."
+        )
+
+
+def unlink_keyfile() -> None:
+    if not valid_keyfile_exists():
+        cli_logger.info("Unable to unlink keyfile: empty keyfile found.")
+    else:
+        keyfile_path = get_keyfile_path()
+        address = get_authorized_address()
+        keyfile_path.write_text("")
+        cli_logger.info(f"Keyfile removed for address: {address}")
+
+
+def init_keyfile() -> None:
+    if valid_keyfile_exists():
+        cli_logger.info(
+            f"Keyfile detected. Please use `ethpm auth unlink` to delete this "
+            "keyfile before initializing a new one."
+        )
+        return
+
+    cli_logger.info(PRIVATE_KEY_WARNING)
+    agreement = parse_bool_flag(
+        "Are you sure you want to proceed with initializing a keyfile? "
+    )
+    if not agreement:
+        cli_logger.info("Aborting keyfile initialization.")
+        return
+
+    private_key = to_bytes(text=input("Please enter your 32-length private key: "))
+    validate_private_key_length(private_key)
+    password = to_bytes(
+        text=input(
+            "Please enter a password to encrypt your keyfile with (Don't forget this password!): "
+        )
+    )
+    keyfile_json = eth_keyfile.create_keyfile_json(private_key, password)
+    ethpm_xdg_root = get_xdg_ethpmcli_root()
+    ethpm_cli_keyfile_path = ethpm_xdg_root / KEYFILE_PATH
+    with atomic_replace(ethpm_cli_keyfile_path) as file:
+        file.write(json.dumps(keyfile_json))
+    address = get_authorized_address()
+    cli_logger.info(f"Encrypted keyfile saved for address: {address}")
+
+
+def valid_keyfile_exists() -> bool:
+    try:
+        get_authorized_address()
+    except AuthorizationError:
+        return False
+    return True
+
+
+def validate_private_key_length(private_key: str) -> None:
+    if len(private_key) != 32:
+        raise AuthorizationError(f"{private_key} is not 32 long")
 
 
 def import_keyfile(keyfile_path: Path) -> None:
     validate_keyfile(keyfile_path)
     ethpm_xdg_root = get_xdg_ethpmcli_root()
     ethpm_cli_keyfile_path = ethpm_xdg_root / KEYFILE_PATH
-    tmp_keyfile = Path(tempfile.NamedTemporaryFile().name)
-    tmp_keyfile.write_text(keyfile_path.read_text())
-    tmp_keyfile.replace(ethpm_cli_keyfile_path)
+    with atomic_replace(ethpm_cli_keyfile_path) as file:
+        file.write(keyfile_path.read_text())
 
 
 def get_keyfile_path() -> Path:
@@ -49,7 +130,7 @@ def get_authorized_address() -> Address:
     Returns the address associated with stored keyfile. No password required.
     """
     keyfile = get_keyfile_data()
-    return keyfile["address"]
+    return add_0x_prefix(keyfile["address"])
 
 
 def get_authorized_private_key(password: str) -> str:

--- a/ethpm_cli/commands/manifest.py
+++ b/ethpm_cli/commands/manifest.py
@@ -11,6 +11,7 @@ from ethpm.validation.manifest import validate_manifest_against_schema
 from ethpm.validation.package import validate_package_name
 from web3 import Web3
 
+from ethpm_cli._utils.input import parse_bool_flag
 from ethpm_cli._utils.logger import cli_logger
 from ethpm_cli._utils.shellart import bold_blue
 from ethpm_cli._utils.solc import (
@@ -448,18 +449,6 @@ def gen_links() -> Optional[Callable[..., Manifest]]:
         actual_kwargs = {k: v for k, v in link_kwargs.items() if v}
         return b.links(**actual_kwargs)
     return None
-
-
-def parse_bool_flag(question: str) -> bool:
-    while True:
-        response = input(f"{question} (y/n) ")
-        if response.lower() == "y":
-            return True
-        elif response.lower() == "n":
-            return False
-        else:
-            cli_logger.info(f"Invalid response: {response}.")
-            continue
 
 
 def write_manifest_to_disk(manifest: Manifest, project_dir: Path) -> None:

--- a/ethpm_cli/commands/package.py
+++ b/ethpm_cli/commands/package.py
@@ -93,7 +93,7 @@ def resolve_install_uri(args: Namespace) -> ResolvedInstallURI:
         )
         registry_address = None
     elif registry_backend.can_translate_uri(args.uri):
-        registry_address, _, _, _, _ = parse_registry_uri(args.uri)
+        registry_address, _, _, _, _, _ = parse_registry_uri(args.uri)
         manifest_uri = registry_backend.fetch_uri_contents(args.uri)
     else:
         manifest_uri = args.uri

--- a/ethpm_cli/config.py
+++ b/ethpm_cli/config.py
@@ -16,7 +16,7 @@ from ethpm_cli._utils.filesystem import atomic_replace
 from ethpm_cli._utils.ipfs import get_ipfs_backend
 from ethpm_cli._utils.logger import cli_logger
 from ethpm_cli._utils.xdg import get_xdg_ethpmcli_root
-from ethpm_cli.commands.auth import get_authorized_private_key, import_keyfile
+from ethpm_cli.commands.auth import get_authorized_private_key
 from ethpm_cli.constants import (
     ETHPM_DIR_ENV_VAR,
     ETHPM_PACKAGES_DIR,
@@ -63,16 +63,14 @@ class Config:
         else:
             chain_id = 1
 
-        if "keyfile_path" in args and args.keyfile_path:
-            import_keyfile(args.keyfile_path)
-
+        # setup auth
         if "keyfile_password" in args and args.keyfile_password:
             self.private_key = get_authorized_private_key(args.keyfile_password)
         self.w3 = setup_w3(chain_id, self.private_key)
 
         # Setup xdg ethpm dir
         self.xdg_ethpmcli_root = get_xdg_ethpmcli_root()
-        setup_xdg_ethpm_dir(self.xdg_ethpmcli_root, self.w3)
+        validate_xdg_ethpm_dir(self.xdg_ethpmcli_root, self.w3)
 
         # Setup projects dir
         if "project_dir" in args and args.project_dir:
@@ -114,7 +112,7 @@ def setup_w3(chain_id: int, private_key: str = None) -> Web3:
     return w3
 
 
-def setup_xdg_ethpm_dir(xdg_ethpmcli_root: Path, w3: Web3) -> None:
+def validate_xdg_ethpm_dir(xdg_ethpmcli_root: Path, w3: Web3) -> None:
     if not xdg_ethpmcli_root.is_dir():
         initialize_xdg_ethpm_dir(xdg_ethpmcli_root, w3)
 

--- a/tests/cli/test_auth_cli.py
+++ b/tests/cli/test_auth_cli.py
@@ -1,0 +1,130 @@
+import json
+
+import pexpect
+import pytest
+from web3.auto.infura import w3
+
+from ethpm_cli.config import initialize_xdg_ethpm_dir
+from ethpm_cli.constants import KEYFILE_PATH
+from ethpm_cli.main import ENTRY_DESCRIPTION
+
+# taken from eth-keyfile readme
+PRIVATE_KEY = b"\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"  # noqa: E501
+PASSWORD = b"foo"
+ENCRYPTED_KEYFILE_JSON = '{"address": "1a642f0e3c3af545e7acbd38b07251b3990914f1", "crypto": {"cipher": "aes-128-ctr", "cipherparams": {"iv": "6087dab2f9fdbbfaddc31a909735c1e6"}, "ciphertext": "5318b4d5bcd28de64ee5559e671353e16f075ecae9f99c7a79a38af5f869aa46", "kdf": "pbkdf2", "kdfparams": {"c": 262144, "dklen": 32, "prf": "hmac-sha256", "salt": "ae3cd4e7013836a3df6bd7241b12db061dbe2c6785853cce422d148a624ce0bd"}, "mac": "517ead924a9d0dc3124507e3393d175ce3ff7c1e96529c6c555ce9e51205e9b2"}, "id": "3198bc9c-6672-5ab3-d995-4942343ae5b6", "version": 3}'  # noqa: E501
+
+
+@pytest.fixture
+def tmp_xdg(tmp_path, monkeypatch):
+    tmp_xdg_dir = tmp_path / "xdg"
+    initialize_xdg_ethpm_dir(tmp_xdg_dir, w3)
+
+    tmp_keyfile = tmp_path / "keyfile.json"
+    tmp_keyfile.write_text(ENCRYPTED_KEYFILE_JSON)
+    return tmp_xdg_dir, tmp_keyfile
+
+
+def test_auth_without_keyfile(tmp_xdg):
+    child = pexpect.spawn("ethpm auth")
+    child.expect(ENTRY_DESCRIPTION)
+    child.expect("\r\n")
+    child.expect(f"No valid keyfile found.")
+
+
+def test_auth_link_keyfile(tmp_xdg):
+    tmp_xdg_dir, tmp_keyfile = tmp_xdg
+    child = pexpect.spawn(f"ethpm auth link --keyfile-path {tmp_keyfile}")
+    child.expect("\r\n")
+    child.expect(
+        f"Keyfile stored for address: 0x1a642f0e3c3af545e7acbd38b07251b3990914f1"
+    )
+    child.expect(
+        "It's now available for use when its password is passed in with the "
+        "`--keyfile-password` flag."
+    )
+    assert (tmp_xdg_dir / KEYFILE_PATH).read_text() == tmp_keyfile.read_text()
+
+
+def test_auth_link_requires_keyfile_path_flag(tmp_xdg):
+    child = pexpect.spawn(f"ethpm auth link")
+    child.expect("\r\n")
+    child.expect(f"Invalid --keyfile-path flag")
+
+
+def test_auth_link_with_invalid_keyfile(tmp_xdg):
+    tmp_xdg_dir, _ = tmp_xdg
+    invalid_keyfile = tmp_xdg_dir / "invalid.json"
+    invalid_keyfile.write_text(json.dumps({"version": 4}))
+    child = pexpect.spawn(f"ethpm auth link --keyfile-path {invalid_keyfile}")
+    child.expect("\r\n")
+    child.expect(
+        f"Keyfile found at {invalid_keyfile} does not look like a supported eth-keyfile object."
+    )
+
+
+def test_auth_link_with_existing_keyfile(tmp_xdg):
+    tmp_xdg_dir, tmp_keyfile = tmp_xdg
+    (tmp_xdg_dir / KEYFILE_PATH).write_text(ENCRYPTED_KEYFILE_JSON)
+    child = pexpect.spawn(f"ethpm auth link --keyfile-path {tmp_keyfile}")
+    child.expect("\r\n")
+    child.expect(
+        f"Keyfile detected at {tmp_xdg_dir / KEYFILE_PATH}. Please use "
+        "`ethpm auth unlink` to delete this"
+    )
+
+
+def test_auth_unlink(tmp_xdg):
+    tmp_xdg_dir, tmp_keyfile = tmp_xdg
+    (tmp_xdg_dir / KEYFILE_PATH).write_text(ENCRYPTED_KEYFILE_JSON)
+    child = pexpect.spawn(f"ethpm auth unlink")
+    child.expect("\r\n")
+    child.expect(
+        "Keyfile removed for address: 0x1a642f0e3c3af545e7acbd38b07251b3990914f1"
+    )
+
+
+def test_auth_unlink_without_stored_keyfile(tmp_xdg):
+    tmp_xdg_dir, tmp_keyfile = tmp_xdg
+    (tmp_xdg_dir / KEYFILE_PATH).write_text("")
+    child = pexpect.spawn(f"ethpm auth unlink")
+    child.expect("\r\n")
+    child.expect("Unable to unlink keyfile: empty keyfile found.")
+
+
+def test_auth_init(tmp_xdg):
+    tmp_xdg_dir, tmp_keyfile = tmp_xdg
+    (tmp_xdg_dir / KEYFILE_PATH).write_text("")
+    child = pexpect.spawn(f"ethpm auth init")
+    child.expect("\r\n")
+    child.expect(
+        "Please be careful when using your private key, it is a sensitive piece of information."
+    )
+    child.expect("Are you sure you want to proceed with initializing a keyfile?")
+    child.sendline("Y")
+    child.expect("Please enter your 32-length private key:")
+    child.sendline(PRIVATE_KEY)
+    child.expect("Please enter a password to encrypt your keyfile with")
+    child.sendline(PASSWORD)
+    child.expect("Encrypted keyfile saved for address:")
+    actual_keyfile_json = json.loads((tmp_xdg_dir / KEYFILE_PATH).read_text())
+    expected_keyfile_json = json.loads(ENCRYPTED_KEYFILE_JSON)
+    assert actual_keyfile_json["address"] == expected_keyfile_json["address"]
+    assert actual_keyfile_json["version"] == expected_keyfile_json["version"]
+
+
+def test_auth_init_abort(tmp_xdg):
+    tmp_xdg_dir, tmp_keyfile = tmp_xdg
+    (tmp_xdg_dir / KEYFILE_PATH).write_text("")
+    child = pexpect.spawn(f"ethpm auth init")
+    child.expect("\r\n")
+    child.expect("Are you sure you want to proceed with initializing a keyfile?")
+    child.sendline("n")
+    child.expect("Aborting keyfile initialization")
+
+
+def test_auth_init_with_existing_keyfile(tmp_xdg):
+    tmp_xdg_dir, tmp_keyfile = tmp_xdg
+    (tmp_xdg_dir / KEYFILE_PATH).write_text(ENCRYPTED_KEYFILE_JSON)
+    child = pexpect.spawn(f"ethpm auth init")
+    child.expect("\r\n")
+    child.expect("Keyfile detected.")


### PR DESCRIPTION
## What was wrong?
`ethpm auth` required users to link an already generated encrypted keyfile. Now, the cli will handle that for you.

A couple new commands introduced...
`ethpm auth` - displays currently authenticated addr
`ethpm auth link --keyfile-path ./path/to/keyfile` - will link an existing keyfile
`ethpm auth unlink` - will unwrite whatever keyfile is stored in the xdg dir
`ethpm auth init` - will display a warning about private key handling, then prompt user for private key / password and store encrypted keyfile json in xdg directory


#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/74196606-d420c700-4c1a-11ea-817b-be45dfe15865.png)

