### PR TITLE
Add missing __init__ file

### DIFF
--- a/ethpm_cli/commands/auth.py
+++ b/ethpm_cli/commands/auth.py
@@ -3,7 +3,6 @@ import tempfile
 from typing import Any, Dict
 
 import eth_keyfile
-from eth_typing import Address
 from eth_utils import to_bytes
 
 from ethpm_cli._utils.xdg import get_xdg_ethpmcli_root
@@ -44,7 +43,7 @@ def validate_keyfile(keyfile_path: Path) -> None:
         )
 
 
-def get_authorized_address() -> Address:
+def get_authorized_address() -> str:
     """
     Returns the address associated with stored keyfile. No password required.
     """

--- a/ethpm_cli/commands/etherscan.py
+++ b/ethpm_cli/commands/etherscan.py
@@ -71,7 +71,7 @@ def make_etherscan_request(contract_addr: str, network: str) -> Dict[str, Any]:
     etherscan_req_uri = f"https://api{network}.etherscan.io/api"
     response = requests.get(  # type: ignore
         etherscan_req_uri,
-        params=[
+        params=[  # type: ignore
             ("module", "contract"),
             ("action", "getsourcecode"),
             ("address", contract_addr),

--- a/ethpm_cli/commands/install.py
+++ b/ethpm_cli/commands/install.py
@@ -5,7 +5,7 @@ import logging
 from pathlib import Path
 import shutil
 import tempfile
-from typing import Any, Dict, Iterable, List, NamedTuple, Tuple
+from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Tuple
 
 from eth_typing import URI
 from eth_utils import to_dict, to_int, to_text, to_tuple
@@ -231,10 +231,13 @@ def update_package(args: Namespace, config: Config) -> None:
     )
 
 
-def pluck_release_data(all_release_data: List[str], target_version: str) -> URI:
+def pluck_release_data(
+    all_release_data: List[str], target_version: str
+) -> Optional[URI]:
     for version, uri in all_release_data:
         if version == target_version:
-            return uri
+            return URI(uri)
+    return None
 
 
 def uninstall_package(package_name: str, config: Config) -> None:

--- a/ethpm_cli/commands/manifest.py
+++ b/ethpm_cli/commands/manifest.py
@@ -484,7 +484,7 @@ def cat_manifest(manifest_path: Path) -> None:
     pretty_print_raw_manifest(raw_manifest)
 
 
-def pretty_print_raw_manifest(raw_manifest) -> None:
+def pretty_print_raw_manifest(raw_manifest: Manifest) -> None:
     manifest = ManifestDisplay(raw_manifest)
     cli_logger.info(f"Package Name: {manifest.package_name}")
     cli_logger.info(f"Package Version: {manifest.package_version}")

--- a/ethpm_cli/commands/registry.py
+++ b/ethpm_cli/commands/registry.py
@@ -18,8 +18,8 @@ from ethpm_cli.exceptions import AmbigiousFileSystem, AuthorizationError, Instal
 
 class StoredRegistry(NamedTuple):
     uri: URI
+    alias: str
     active: bool = False
-    alias: Optional[str] = None
     ens: Optional[str] = None
 
     @property
@@ -59,7 +59,7 @@ def list_registries(config: Config) -> None:
         )
     registry_store = json.loads((config.xdg_ethpmcli_root / REGISTRY_STORE).read_text())
     installed_registries = [
-        StoredRegistry(reg, data["active"], data["alias"], data["ens"])
+        StoredRegistry(reg, data["alias"], data["active"], data["ens"])
         for reg, data in registry_store.items()
     ]
     for registry in installed_registries:
@@ -138,7 +138,7 @@ def resolve_uri_and_alias(
 def get_all_registries(store_path: Path) -> Iterable[StoredRegistry]:
     store_data = json.loads(store_path.read_text())
     for registry_uri, data in store_data.items():
-        yield StoredRegistry(registry_uri, data["active"], data["alias"], data["ens"])
+        yield StoredRegistry(registry_uri, data["alias"], data["active"], data["ens"])
 
 
 def get_active_registry(store_path: Path) -> StoredRegistry:


### PR DESCRIPTION
## What was wrong?
Sphinx-argparse (aka auto-doc cli commands) was broken in the docs on master but worked on local builds. Digging into it - it turns out there's no `__init__.py` file in `ethpm_cli/commands` - which also brought up some missed types.

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/74375782-30f8ba80-4d9e-11ea-87ab-38cd6d933d0c.png)
