### PR TITLE
Support default chain id in etherscan uris

### DIFF
--- a/ethpm_cli/_utils/etherscan.py
+++ b/ethpm_cli/_utils/etherscan.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Tuple
 from urllib import parse
 
 from eth_utils import is_checksum_address
@@ -20,10 +20,10 @@ def is_etherscan_uri(value: Any) -> bool:
     if parsed.scheme != "etherscan" or not parsed.netloc:
         return False
 
-    if ":" not in parsed.netloc:
+    if parsed.path:
         return False
 
-    address, chain_id = parsed.netloc.split(":")
+    address, chain_id = parse_etherscan_uri(value)
     if not is_checksum_address(address):
         return False
 
@@ -31,6 +31,15 @@ def is_etherscan_uri(value: Any) -> bool:
         return False
 
     return True
+
+
+def parse_etherscan_uri(uri: str) -> Tuple[str, str]:
+    parsed = parse.urlparse(uri)
+    if ":" in parsed.netloc:
+        address, _, chain_id = parsed.netloc.partition(":")
+    else:
+        address, chain_id = (parsed.netloc, "1")
+    return address, chain_id
 
 
 def get_etherscan_network(chain_id: str) -> str:

--- a/ethpm_cli/commands/etherscan.py
+++ b/ethpm_cli/commands/etherscan.py
@@ -1,7 +1,6 @@
 import json
 import os
 from typing import Any, Dict, Iterable, Tuple
-from urllib import parse
 
 from eth_typing import URI
 from eth_utils import to_dict, to_hex, to_int
@@ -10,7 +9,11 @@ from ethpm.tools import builder
 from ethpm.uri import create_latest_block_uri
 import requests
 
-from ethpm_cli._utils.etherscan import get_etherscan_network, is_etherscan_uri
+from ethpm_cli._utils.etherscan import (
+    get_etherscan_network,
+    is_etherscan_uri,
+    parse_etherscan_uri,
+)
 from ethpm_cli.config import get_ipfs_backend, setup_w3
 from ethpm_cli.constants import ETHERSCAN_KEY_ENV_VAR
 from ethpm_cli.exceptions import ContractNotVerified
@@ -41,7 +44,7 @@ class EtherscanURIBackend(BaseURIBackend):
 def build_etherscan_manifest(
     uri: URI, package_name: str, version: str
 ) -> Iterable[Tuple[str, Any]]:
-    address, chain_id = parse.urlparse(uri).netloc.split(":")
+    address, chain_id = parse_etherscan_uri(uri)
     network = get_etherscan_network(chain_id)
     body = make_etherscan_request(address, network)
     contract_type = body["ContractName"]

--- a/tests/cli/test_activate.py
+++ b/tests/cli/test_activate.py
@@ -118,10 +118,6 @@ def test_activate_ipfs_uri_with_factories_and_deployments():
     # test contract factory is available
     child.sendline("Address_factory")
     child.expect("web3._utils.datatypes.LinkableContract")
-    # test deployment is available
-    child.sendline("mainnet_BaseRegistrarImplementation")
-    child.expect("web3._utils.datatypes.LinkableContract at")
-    child.close()
 
 
 def test_activate_github_uri_with_insufficient_contract_types_and_deployments():

--- a/tests/cli/test_ethpm.py
+++ b/tests/cli/test_ethpm.py
@@ -9,7 +9,7 @@ from ethpm_cli.main import ENTRY_DESCRIPTION
 
 def test_ethpm_list(test_assets_dir):
     ethpm_dir = test_assets_dir / "multiple" / ETHPM_PACKAGES_DIR
-    child = pexpect.spawn(f"ethpm list --ethpm-dir {ethpm_dir}")
+    child = pexpect.spawn(f"ethpm list --ethpm-dir {ethpm_dir}", timeout=30)
     child.expect(ENTRY_DESCRIPTION)
     child.expect("\r\n")
     child.expect("owned")

--- a/tests/core/_utils/test_etherscan.py
+++ b/tests/core/_utils/test_etherscan.py
@@ -6,6 +6,7 @@ from ethpm_cli._utils.etherscan import is_etherscan_uri
 @pytest.mark.parametrize(
     "uri,expected",
     (
+        ("etherscan://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", True),
         ("etherscan://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:1", True),
         ("etherscan://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:3", True),
         ("etherscan://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:4", True),
@@ -15,10 +16,10 @@ from ethpm_cli._utils.etherscan import is_etherscan_uri
         ("etherscan://invalid:1", False),
         # non-checksummed
         ("etherscan://0x6b5da3ca4286baa7fbaf64eeee1834c7d430b729:1", False),
-        # bad path
+        # paths are not allowed
         ("etherscan://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729/1", False),
+        ("etherscan://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729/owned@1.0.0", False),
         # no chain_id
-        ("etherscan://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729", False),
         ("etherscan://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:", False),
         ("etherscan://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:10", False),
         ("://0x6b5DA3cA4286Baa7fBaf64EEEE1834C7d430B729:1", False),


### PR DESCRIPTION
## What was wrong?
The ethpm URI spec was recently updated to support default chain IDs of `"1"` if they were omitted from the uri. For consistency, this behavior is now supported in etherscan uris as well.

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/74885731-88190500-5333-11ea-8c0e-2bf5ad9c8450.png)

