### PR TITLE
Registry explore cmd

### DIFF
--- a/ethpm_cli/commands/registry.py
+++ b/ethpm_cli/commands/registry.py
@@ -114,21 +114,15 @@ def activate_registry(uri_or_alias: str, config: Config) -> None:
 
 def explore_registry(uri: str, config: Config) -> None:
     if is_valid_registry_uri(URI(uri)):
-        (
-            address,
-            chain_id,
-            pkg_name,
-            pkg_version,
-            namespaced_asset,
-            ens,
-        ) = parse_registry_uri(uri)
-        config.w3.enable_unstable_package_management_api()
-        config.w3.pm.set_registry(address)
+        parsed_registry_uri = parse_registry_uri(uri)
+        config.w3.pm.set_registry(parsed_registry_uri.address)
         package_names = config.w3.pm.get_all_package_names()
         display_packages(package_names, config)
 
     else:
-        raise UriNotSupportedError("Cannot resolve both an alias and registry uri.")
+        raise UriNotSupportedError(
+            f"Invalid URI: {uri}, unable to explore. Registry URI definition can be found at https://docs.ethpm.com/uris#registry-uris."  # noqa: E501
+        )
 
 
 def resolve_uri_or_alias(uri_or_alias: str, store_path: Path) -> StoredRegistry:
@@ -232,13 +226,10 @@ def generate_registry_store_data(
 def display_packages(all_package_names: Iterable[str], config: Config) -> None:
     for package_name in all_package_names:
         all_releases = config.w3.pm.get_all_package_releases(package_name)
-        cli_logger.info(f"Retrieving releases for {bold_blue(package_name)}: \n")
-        for release in all_releases:
-            (version, manifest_uri) = release
+        cli_logger.info(f"Retrieving all releases for {bold_blue(package_name)}: \n")
+        for version, manifest_uri in all_releases:
             cli_logger.info(f"{bold_green(version)} --- ({bold_white(manifest_uri)})")
         cli_logger.info(
-            f"Total: {config.w3.pm.get_release_count(package_name)}\n"
+            f"Total releases: {config.w3.pm.get_release_count(package_name)}\n"
         )
-    cli_logger.info(
-        f"Packages in the registry: {config.w3.pm.get_package_count()}\n"
-    )
+    cli_logger.info(f"Packages in the registry: {config.w3.pm.get_package_count()}\n")

--- a/ethpm_cli/commands/registry.py
+++ b/ethpm_cli/commands/registry.py
@@ -13,12 +13,7 @@ from ethpm_cli._utils.logger import cli_logger
 from ethpm_cli._utils.shellart import bold_blue, bold_green, bold_white
 from ethpm_cli.config import Config
 from ethpm_cli.constants import REGISTRY_STORE
-from ethpm_cli.exceptions import (
-    AmbigiousFileSystem,
-    AuthorizationError,
-    InstallError,
-    UriNotSupportedError,
-)
+from ethpm_cli.exceptions import AmbigiousFileSystem, AuthorizationError, InstallError
 
 
 class StoredRegistry(NamedTuple):
@@ -112,17 +107,17 @@ def activate_registry(uri_or_alias: str, config: Config) -> None:
         write_store_data_to_disk(activated_store_data, store_path)
 
 
-def explore_registry(uri: str, config: Config) -> None:
-    if is_valid_registry_uri(URI(uri)):
-        parsed_registry_uri = parse_registry_uri(uri)
+def explore_registry(uri_or_alias: str, config: Config) -> None:
+    if is_valid_registry_uri(uri_or_alias):
+        parsed_registry_uri = parse_registry_uri(uri_or_alias)
         config.w3.pm.set_registry(parsed_registry_uri.address)
-        package_names = config.w3.pm.get_all_package_names()
-        display_packages(package_names, config)
-
     else:
-        raise UriNotSupportedError(
-            f"Invalid URI: {uri}, unable to explore. Registry URI definition can be found at https://docs.ethpm.com/uris#registry-uris."  # noqa: E501
-        )
+        store_path = config.xdg_ethpmcli_root / REGISTRY_STORE
+        registry = resolve_uri_and_alias(None, uri_or_alias, store_path)
+        parsed_registry_uri = parse_registry_uri(registry.uri)
+        config.w3.pm.set_registry(parsed_registry_uri.address)
+    package_names = config.w3.pm.get_all_package_names()
+    display_packages(package_names, config)
 
 
 def resolve_uri_or_alias(uri_or_alias: str, store_path: Path) -> StoredRegistry:

--- a/ethpm_cli/parser.py
+++ b/ethpm_cli/parser.py
@@ -141,6 +141,12 @@ def add_package_version_to_parser(
     )
 
 
+def add_uri_to_parser(parser: argparse.ArgumentParser, help_msg: str,) -> None:
+    parser.add_argument(
+        "uri", action="store", type=str, help=help_msg,
+    )
+
+
 parser = argparse.ArgumentParser(description="ethpm-cli")
 ethpm_parser = parser.add_subparsers(help="CLI commands", dest="command")
 
@@ -272,6 +278,12 @@ def registry_remove_cmd(args: argparse.Namespace) -> None:
     cli_logger.info(f"Registry: {args.uri_or_alias} removed from registry store.")
 
 
+def registry_explore_cmd(args: argparse.Namespace) -> None:
+    # config = Config(args)
+    # explore_registry(args.uri)
+    return None
+
+
 registry_parser = ethpm_parser.add_parser("registry", help="Manage the registry store.")
 registry_subparsers = registry_parser.add_subparsers(dest="registry")
 
@@ -323,6 +335,13 @@ registry_activate_parser.add_argument(
 )
 registry_activate_parser.set_defaults(func=registry_activate_cmd)
 
+# ethpm registry explore
+registry_explore_parser = registry_subparsers.add_parser(
+    "explore", help="Explore a registry's list of released packages and manifest uris.",
+)
+add_uri_to_parser(
+    registry_explore_parser, "Registry URI of target package.",
+)
 
 #
 # ethpm create
@@ -482,12 +501,6 @@ install_parser = ethpm_parser.add_parser(
     "install", help="Install a package to a local ethPM directory."
 )
 install_parser.add_argument(
-    "uri",
-    action="store",
-    type=str,
-    help="IPFS / Github / Etherscan / Registry URI of target package.",
-)
-install_parser.add_argument(
     "--local-ipfs",
     dest="local_ipfs",
     action="store_true",
@@ -503,6 +516,9 @@ add_package_version_to_parser(
 )
 add_alias_arg_to_parser(install_parser)
 add_ethpm_dir_arg_to_parser(install_parser)
+add_uri_to_parser(
+    install_parser, "IPFS / Github / Etherscan / Registry URI of target package."
+)
 install_parser.set_defaults(func=install_action)
 
 #

--- a/ethpm_cli/parser.py
+++ b/ethpm_cli/parser.py
@@ -29,6 +29,7 @@ from ethpm_cli.commands.registry import (
     activate_registry,
     add_registry,
     deploy_registry,
+    explore_registry,
     get_active_registry,
     list_registries,
     remove_registry,
@@ -279,9 +280,9 @@ def registry_remove_cmd(args: argparse.Namespace) -> None:
 
 
 def registry_explore_cmd(args: argparse.Namespace) -> None:
-    # config = Config(args)
-    # explore_registry(args.uri)
-    return None
+    config = Config(args)
+    cli_logger.info(f"Looking for packages @ {args.uri}: \n")
+    explore_registry(args.uri, config)
 
 
 registry_parser = ethpm_parser.add_parser("registry", help="Manage the registry store.")
@@ -307,8 +308,8 @@ registry_list_parser.set_defaults(func=registry_list_cmd)
 registry_add_parser = registry_subparsers.add_parser(
     "add", help="Add a registry to registry store."
 )
-registry_add_parser.add_argument(
-    "uri", action="store", type=str, help="Registry URI for target registry."
+add_uri_to_parser(
+    registry_add_parser, "Registry URI for target registry.",
 )
 add_alias_arg_to_parser(registry_add_parser)
 registry_add_parser.set_defaults(func=registry_add_cmd)
@@ -340,8 +341,9 @@ registry_explore_parser = registry_subparsers.add_parser(
     "explore", help="Explore a registry's list of released packages and manifest uris.",
 )
 add_uri_to_parser(
-    registry_explore_parser, "Registry URI of target package.",
+    registry_explore_parser, "Registry URI for target registry.",
 )
+registry_explore_parser.set_defaults(func=registry_explore_cmd)
 
 #
 # ethpm create

--- a/ethpm_cli/parser.py
+++ b/ethpm_cli/parser.py
@@ -142,7 +142,7 @@ def add_package_version_to_parser(
     )
 
 
-def add_uri_to_parser(parser: argparse.ArgumentParser, help_msg: str,) -> None:
+def add_uri_to_parser(parser: argparse.ArgumentParser, help_msg: str) -> None:
     parser.add_argument(
         "uri", action="store", type=str, help=help_msg,
     )

--- a/ethpm_cli/parser.py
+++ b/ethpm_cli/parser.py
@@ -124,7 +124,7 @@ def add_manifest_path_to_parser(
     )
 
 
-def add_package_name_to_parser(parser: argparse.ArgumentParser, help_msg: str,) -> None:
+def add_package_name_to_parser(parser: argparse.ArgumentParser, help_msg: str) -> None:
     parser.add_argument(
         "--package-name", dest="package_name", action="store", type=str, help=help_msg
     )
@@ -145,6 +145,12 @@ def add_package_version_to_parser(
 def add_uri_to_parser(parser: argparse.ArgumentParser, help_msg: str) -> None:
     parser.add_argument(
         "uri", action="store", type=str, help=help_msg,
+    )
+
+
+def add_uri_or_alias_to_parser(parser: argparse.ArgumentParser, help_msg: str) -> None:
+    parser.add_argument(
+        "uri_or_alias", action="store", type=str, help=help_msg,
     )
 
 
@@ -318,8 +324,8 @@ registry_add_parser.set_defaults(func=registry_add_cmd)
 registry_remove_parser = registry_subparsers.add_parser(
     "remove", help="Remove a registry from the registry store."
 )
-registry_remove_parser.add_argument(
-    "uri_or_alias", type=str, help="Registry URI or alias for registry to remove."
+add_uri_or_alias_to_parser(
+    registry_remove_parser, "Registry URI or alias for registry to remove."
 )
 registry_remove_parser.set_defaults(func=registry_remove_cmd)
 
@@ -328,11 +334,8 @@ registry_activate_parser = registry_subparsers.add_parser(
     "activate",
     help="Activate a registry to be used as the default registry for releasing new packages.",
 )
-registry_activate_parser.add_argument(
-    "uri_or_alias",
-    action="store",
-    type=str,
-    help="Registry URI or alias for target registry.",
+add_uri_or_alias_to_parser(
+    registry_activate_parser, "Registry URI or alias for target registry."
 )
 registry_activate_parser.set_defaults(func=registry_activate_cmd)
 

--- a/ethpm_cli/parser.py
+++ b/ethpm_cli/parser.py
@@ -287,8 +287,8 @@ def registry_remove_cmd(args: argparse.Namespace) -> None:
 
 def registry_explore_cmd(args: argparse.Namespace) -> None:
     config = Config(args)
-    cli_logger.info(f"Looking for packages @ {args.uri}: \n")
-    explore_registry(args.uri, config)
+    cli_logger.info(f"Looking for packages @ {args.uri_or_alias}: \n")
+    explore_registry(args.uri_or_alias, config)
 
 
 registry_parser = ethpm_parser.add_parser("registry", help="Manage the registry store.")
@@ -343,7 +343,7 @@ registry_activate_parser.set_defaults(func=registry_activate_cmd)
 registry_explore_parser = registry_subparsers.add_parser(
     "explore", help="Explore a registry's list of released packages and manifest uris.",
 )
-add_uri_to_parser(
+add_uri_or_alias_to_parser(
     registry_explore_parser, "Registry URI for target registry.",
 )
 registry_explore_parser.set_defaults(func=registry_explore_cmd)

--- a/tests/cli/test_registry_cli.py
+++ b/tests/cli/test_registry_cli.py
@@ -67,3 +67,10 @@ def test_ethpm_registry_commands():
     child_four.expect(r"\(active\)")
     child_four.expect("erc1319://0xabc0000000000000000000000000000000000000:3")
     child_four.expect("yours")
+
+    # test registry explore
+    child_five = pexpect.spawn(
+        f"ethpm registry explore erc1319://0x16763EaE3709e47eE6140507Ff84A61c23B0098A:1"
+    )
+    child_five.expect(ENTRY_DESCRIPTION)
+    child_five.expect("\r\n")

--- a/tests/cli/test_registry_cli.py
+++ b/tests/cli/test_registry_cli.py
@@ -1,8 +1,7 @@
 import pexpect
 
+from ethpm_cli._utils.shellart import bold_blue, bold_green, bold_white
 from ethpm_cli.main import ENTRY_DESCRIPTION
-
-# from ethpm_cli._utils.shellart import bold_blue, bold_green, bold_white
 
 
 def test_ethpm_registry_commands():
@@ -70,9 +69,6 @@ def test_ethpm_registry_commands():
     child_four.expect("erc1319://0xabc0000000000000000000000000000000000000:3")
     child_four.expect("yours")
 
-
-def test_ethpm_registry_explore():
-    # first_package_name = bold_blue("augurreputation-rep")
     # test registry explore
     child_five = pexpect.spawn(
         f"ethpm registry explore erc1319://0x16763EaE3709e47eE6140507Ff84A61c23B0098A:1",
@@ -83,7 +79,31 @@ def test_ethpm_registry_explore():
     child_five.expect(
         f"Looking for packages @ erc1319://0x16763EaE3709e47eE6140507Ff84A61c23B0098A:1: "  # noqa: 501
     )
+    child_five.expect("\r\n\r\n")
+    child_five.expect_exact(
+        f"Retrieving all releases for {bold_blue('augurreputation-rep')}: "
+    )
+    child_five.expect("\r\n\r\n")
+    child_five.expect_exact(
+        f"{bold_green('1.0.0')} --- ({bold_white('ipfs://QmXsunnsZWYRfCN1YyfJJoFLeRxZrSBhQC9b2HeXvYHrAH')})"  # noqa: 501
+    )
     child_five.expect("\r\n")
-    # child_five.expect(f"Retrieving all releases for {first_package_name}: ")
-    # child_five.expect("\r\n")
-    # child_five.expect(f"1.0.0. --- (ipfs://QmXsunnsZWYRfCN1YyfJJoFLeRxZrSBhQC9b2HeXvYHrAH)")
+    child_five.expect(f"Total releases: 1")
+    child_five.expect("\r\n\r\n")
+    child_five.expect_exact(f"Retrieving all releases for {bold_blue('dai-dai')}: ")
+    child_five.expect("\r\n\r\n")
+    child_five.expect_exact(
+        f"{bold_green('1.0.0')} --- ({bold_white('ipfs://QmTFxJbaJvpgASxxdqFPSvYr1XLWgXR9fv241jLXsELiXP')})"  # noqa: 501
+    )
+    child_five.expect("\r\n")
+    child_five.expect(f"Total releases: 1")
+    child_five.expect("\r\n\r\n")
+    child_five.expect_exact(
+        f"Retrieving all releases for {bold_blue('bitfinexleo-leo')}: "
+    )
+    child_five.expect("\r\n\r\n")
+    child_five.expect_exact(
+        f"{bold_green('1.0.0')} --- ({bold_white('ipfs://QmS2JVar9KqSdDahRtHaFcm9qYkbCsjXLhTcPRq4zafffo')})"  # noqa: 501
+    )
+    child_five.expect("\r\n")
+    child_five.expect(f"Total releases: 1")

--- a/tests/cli/test_registry_cli.py
+++ b/tests/cli/test_registry_cli.py
@@ -2,6 +2,8 @@ import pexpect
 
 from ethpm_cli.main import ENTRY_DESCRIPTION
 
+# from ethpm_cli._utils.shellart import bold_blue, bold_green, bold_white
+
 
 def test_ethpm_registry_commands():
     # test registry add
@@ -68,9 +70,20 @@ def test_ethpm_registry_commands():
     child_four.expect("erc1319://0xabc0000000000000000000000000000000000000:3")
     child_four.expect("yours")
 
+
+def test_ethpm_registry_explore():
+    # first_package_name = bold_blue("augurreputation-rep")
     # test registry explore
     child_five = pexpect.spawn(
-        f"ethpm registry explore erc1319://0x16763EaE3709e47eE6140507Ff84A61c23B0098A:1"
+        f"ethpm registry explore erc1319://0x16763EaE3709e47eE6140507Ff84A61c23B0098A:1",
+        timeout=90,
     )
     child_five.expect(ENTRY_DESCRIPTION)
     child_five.expect("\r\n")
+    child_five.expect(
+        f"Looking for packages @ erc1319://0x16763EaE3709e47eE6140507Ff84A61c23B0098A:1: "  # noqa: 501
+    )
+    child_five.expect("\r\n")
+    # child_five.expect(f"Retrieving all releases for {first_package_name}: ")
+    # child_five.expect("\r\n")
+    # child_five.expect(f"1.0.0. --- (ipfs://QmXsunnsZWYRfCN1YyfJJoFLeRxZrSBhQC9b2HeXvYHrAH)")

--- a/tests/core/test_registry.py
+++ b/tests/core/test_registry.py
@@ -5,11 +5,12 @@ import pytest
 from ethpm_cli.commands.registry import (
     activate_registry,
     add_registry,
+    explore_registry,
     generate_registry_store_data,
     remove_registry,
 )
 from ethpm_cli.constants import REGISTRY_STORE
-from ethpm_cli.exceptions import InstallError
+from ethpm_cli.exceptions import InstallError, UriNotSupportedError
 
 URI_1 = "erc1319://0x1230000000000000000000000000000000000000:1"
 URI_2 = "erc1319://0xabc0000000000000000000000000000000000000:1"
@@ -141,3 +142,8 @@ def test_unable_to_activate_nonexistent_aliased_registry(config):
     add_registry(URI_1, "mine", config)
     with pytest.raises(InstallError):
         activate_registry("other", config)
+
+
+def test_explore_uri_invalid_raises_error(config):
+    with pytest.raises(UriNotSupportedError):
+        explore_registry("test://foo:1", config)

--- a/tests/core/test_registry.py
+++ b/tests/core/test_registry.py
@@ -145,12 +145,11 @@ def test_unable_to_activate_nonexistent_aliased_registry(config):
 
 
 @pytest.mark.parametrize(
-    "uri,alias,valid,expected",
+    "uri,alias,expected",
     (
         (
             URI_1,
             "home",
-            True,
             {
                 "uri": "erc1319://0x1230000000000000000000000000000000000000:1",
                 "alias": "home",
@@ -159,33 +158,29 @@ def test_unable_to_activate_nonexistent_aliased_registry(config):
         (
             URI_2,
             "owned",
-            True,
             {
                 "uri": "erc1319://0xabc0000000000000000000000000000000000000:1",
                 "alias": "owned",
             },
         ),
-        (
-            URI_1,
-            "fake",
-            False,
-            {
-                "uri": "erc1319://0x1230000000000000000000000000000000000000:1",
-                "alias": "fake",
-            },
-        ),
     ),
 )
-def test_resolve_uri_or_alias_raises_error(config, uri, alias, valid, expected):
+def test_resolve_uri_or_alias(config, uri, alias, expected):
     store_path = config.xdg_ethpmcli_root / REGISTRY_STORE
     add_registry(uri, alias, config)
-    if valid:
-        registry = resolve_uri_or_alias(alias, store_path)
-        assert registry.alias == expected["alias"]
-        registry = resolve_uri_or_alias(uri, store_path)
-        assert registry.uri == expected["uri"]
-    else:
-        with pytest.raises(InstallError):
-            resolve_uri_or_alias("other", store_path)
-        with pytest.raises(InstallError):
-            resolve_uri_or_alias(URI_2, store_path)
+    registry = resolve_uri_or_alias(alias, store_path)
+    assert registry.alias == expected["alias"]
+    registry = resolve_uri_or_alias(uri, store_path)
+    assert registry.uri == expected["uri"]
+
+
+@pytest.mark.parametrize(
+    "uri,alias", ((URI_1, "home",), (URI_2, "owned",),),
+)
+def test_resolve_uri_or_alias_raises_install_error(config, uri, alias):
+    store_path = config.xdg_ethpmcli_root / REGISTRY_STORE
+    add_registry(uri, alias, config)
+    with pytest.raises(InstallError):
+        resolve_uri_or_alias("other", store_path)
+    with pytest.raises(InstallError):
+        resolve_uri_or_alias("foo://", store_path)

--- a/tests/core/test_registry.py
+++ b/tests/core/test_registry.py
@@ -5,12 +5,11 @@ import pytest
 from ethpm_cli.commands.registry import (
     activate_registry,
     add_registry,
-    explore_registry,
     generate_registry_store_data,
     remove_registry,
 )
 from ethpm_cli.constants import REGISTRY_STORE
-from ethpm_cli.exceptions import InstallError, UriNotSupportedError
+from ethpm_cli.exceptions import InstallError
 
 URI_1 = "erc1319://0x1230000000000000000000000000000000000000:1"
 URI_2 = "erc1319://0xabc0000000000000000000000000000000000000:1"
@@ -142,8 +141,3 @@ def test_unable_to_activate_nonexistent_aliased_registry(config):
     add_registry(URI_1, "mine", config)
     with pytest.raises(InstallError):
         activate_registry("other", config)
-
-
-def test_explore_uri_invalid_raises_error(config):
-    with pytest.raises(UriNotSupportedError):
-        explore_registry("test://foo:1", config)


### PR DESCRIPTION
## What was wrong?

Issue #88 

## How was it fixed?

Added a new subparser to `registry` that accepts a valid URI and prints the total releases with their corresponding `version` and `manifest_uri` as well as the package name. 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/236x/90/06/f5/9006f5af52cdfd2f00035f213f3606fe--funny-animals-funny-cats.jpg)
