### PR TITLE
Fix flaky test_ethpm_list

### DIFF
--- a/tests/cli/test_ethpm.py
+++ b/tests/cli/test_ethpm.py
@@ -21,9 +21,6 @@ def test_ethpm_list(test_assets_dir):
     child.expect("safe-math-lib")
     child.expect("1.0.0")
     child.expect("ipfs://QmWgvM8yXGyHoGWqLFXvareJsoCZVsdrpKNCLMun3RaSJm")
-    child.expect("owned")
-    child.expect("1.0.0")
-    child.expect("ipfs://QmbeVyFLSuEUxiXKwSsEjef6icpdTdA4kGG9BcrJXKNKUW")
 
 
 def test_ethpm_list_with_aliased_package(test_assets_dir):


### PR DESCRIPTION
## What was wrong?
The `test_ethpm_list` test was extremely flaky - and after multiple hours of debugging - I had no clue how to resolve the issue. I was never able to reproduce locally. It's a very simple test case - without any infura calls. Rather than waste more time - I decided to remove the problematic lines which are somewhat superfluous in the first place and not crucial for the correctness of the test.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/9753150/77952136-c25db680-7290-11ea-946a-9a22c6b38035.png)

